### PR TITLE
[Bug] fix import order bug

### DIFF
--- a/docs/issues/2026-01-15-account-reconciliation-bug.md
+++ b/docs/issues/2026-01-15-account-reconciliation-bug.md
@@ -1,0 +1,24 @@
+# Description
+
+When the Girokonto A was synced first (with data starting from 2025-01-20), and then Girokonto B was synced second (with data going back to 2024-01-25), there's a discrepancy of in Girokonto A account balance if Girokonto B transfers money regularly to Girokonto A.
+
+## Root Cause
+
+The problem is in the `TransferReconciliationService.detect_transfer()` method and the subsequent flow in `TransactionImportService`. When processing a Girokonto B transaction from 2024, the system:
+* Detects that the counterparty IBAN (Girokonto A) has an account mapping. Thus, marks as internal transfer
+* Creates journal entries that debit Girokonto A and credit Girokonto B
+But this is incorrect because:
+* Girokonto A's opening balance date is 2025-01-20
+* Transactions before that date are already "baked into" Girokonto A's opening balance.
+* Adding explicit debits to Girokonto A for pre-opening-balance transfers causes double-counting.
+
+## Solution
+
+The fix creates **opening balance adjustments** for pre-opening-balance internal transfers. We did not need to make any changes to our core domain. We just added a service `OpeningBalanceAdjustmentService` and created one more `TransactionSource` for easier filtering.
+
+## How It Works
+
+For an incoming transfer of X EUR to account A that predates A's opening balance:
+- The internal transfer creates: Debit A (X), Credit B (X)
+- The adjustment creates: Debit Equity (X), Credit A (X)
+- Net effect on A: 0 (the money is correctly attributed to the opening balance)

--- a/services/backend/src/swen/application/commands/integration/batch_sync_command.py
+++ b/services/backend/src/swen/application/commands/integration/batch_sync_command.py
@@ -18,6 +18,7 @@ from swen.application.dtos.integration import (
     SyncStartedEvent,
 )
 from swen.application.queries import ListAccountMappingsQuery
+from swen.domain.accounting.well_known_accounts import WellKnownAccounts
 from swen.domain.banking.repositories import BankCredentialRepository
 from swen.domain.settings.repositories import UserSettingsRepository
 from swen.domain.shared.iban import extract_blz_from_iban
@@ -25,10 +26,6 @@ from swen.domain.shared.time import utc_now
 
 if TYPE_CHECKING:
     from swen.application.factories import RepositoryFactory
-
-
-# Required account for opening balance creation
-OPENING_BALANCE_ACCOUNT_NUMBER = "2000"
 
 
 class BatchSyncCommand:
@@ -52,7 +49,7 @@ class BatchSyncCommand:
     async def from_factory(cls, factory: RepositoryFactory) -> BatchSyncCommand:
         account_repo = factory.account_repository()
         opening_balance_account = await account_repo.find_by_account_number(
-            OPENING_BALANCE_ACCOUNT_NUMBER,
+            WellKnownAccounts.OPENING_BALANCE_EQUITY,
         )
 
         return cls(

--- a/services/backend/src/swen/application/commands/integration/transaction_sync_command.py
+++ b/services/backend/src/swen/application/commands/integration/transaction_sync_command.py
@@ -22,6 +22,7 @@ from swen.domain.accounting.services import (
     OPENING_BALANCE_IBAN_KEY,
     OpeningBalanceService,
 )
+from swen.domain.accounting.well_known_accounts import WellKnownAccounts
 from swen.domain.banking.ports import BankConnectionPort
 from swen.domain.banking.repositories import (
     BankAccountRepository,
@@ -46,8 +47,8 @@ from swen.infrastructure.persistence.sqlalchemy.repositories.factory import (
 )
 
 if TYPE_CHECKING:
-    from swen.application.ports.identity import CurrentUser
     from swen.application.factories import RepositoryFactory
+    from swen.application.ports.identity import CurrentUser
     from swen.domain.accounting.repositories import (
         AccountRepository,
         TransactionRepository,
@@ -83,9 +84,6 @@ class _SyncContext:
 
 class TransactionSyncCommand:
     """Coordinate bank fetch, TAN handling, import, and opening balance logic."""
-
-    # Account number for the Opening Balance equity account
-    OPENING_BALANCE_ACCOUNT_NUMBER = "2000"
 
     def __init__(  # noqa: PLR0913
         self,
@@ -748,12 +746,12 @@ class TransactionSyncCommand:
             return None
 
         opening_balance_account = await self._account_repo.find_by_account_number(
-            self.OPENING_BALANCE_ACCOUNT_NUMBER,
+            WellKnownAccounts.OPENING_BALANCE_EQUITY,
         )
         if not opening_balance_account:
             logger.warning(
                 "Cannot create opening balance: equity account %s not found.",
-                self.OPENING_BALANCE_ACCOUNT_NUMBER,
+                WellKnownAccounts.OPENING_BALANCE_EQUITY,
             )
             return None
 

--- a/services/backend/src/swen/application/queries/integration/__init__.py
+++ b/services/backend/src/swen/application/queries/integration/__init__.py
@@ -13,6 +13,9 @@ from swen.application.queries.integration.list_imports_query import (
     ImportStatistics,
     ListImportsQuery,
 )
+from swen.application.queries.integration.opening_balance_query import (
+    OpeningBalanceQuery,
+)
 from swen.application.queries.integration.reconciliation_query import (
     ReconciliationQuery,
 )
@@ -32,6 +35,7 @@ __all__ = [
     "ListAccountMappingsQuery",
     "ListImportsQuery",
     "MappingWithAccount",
+    "OpeningBalanceQuery",
     "ReconciliationQuery",
     "SyncRecommendationQuery",
     "SyncStatusQuery",

--- a/services/backend/src/swen/application/queries/integration/opening_balance_query.py
+++ b/services/backend/src/swen/application/queries/integration/opening_balance_query.py
@@ -1,0 +1,69 @@
+"""Query for opening balance information needed during reconciliation.
+
+This query encapsulates the logic for finding opening balance dates and
+checking for existing adjustments. These are operational concerns for
+the reconciliation fix, not first-class domain concepts.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING, Optional
+
+from swen.domain.shared.iban import normalize_iban
+
+if TYPE_CHECKING:
+    from swen.application.factories import RepositoryFactory
+    from swen.domain.accounting.repositories import TransactionRepository
+
+
+class OpeningBalanceQuery:
+    """Query for opening balance information needed during reconciliation."""
+
+    def __init__(self, transaction_repository: TransactionRepository):
+        self._repo = transaction_repository
+
+    @classmethod
+    def from_factory(cls, factory: RepositoryFactory) -> OpeningBalanceQuery:
+        return cls(transaction_repository=factory.transaction_repository())
+
+    async def get_date_for_iban(self, iban: str) -> Optional[date]:
+        """Find the opening balance date for an account by IBAN."""
+        normalized = normalize_iban(iban)
+        if not normalized:
+            return None
+
+        transactions = await self._repo.find_by_metadata(
+            metadata_key="is_opening_balance",
+            metadata_value=True,
+        )
+
+        for txn in transactions:
+            txn_iban = normalize_iban(txn.get_metadata_raw("opening_balance_iban"))
+            if txn_iban == normalized:
+                return txn.date.date() if txn.date else None
+
+        return None
+
+    async def adjustment_exists_for_transfer(
+        self,
+        iban: str,
+        transfer_hash: str,
+    ) -> bool:
+        normalized = normalize_iban(iban)
+        if not normalized or not transfer_hash:
+            return False
+
+        # Query adjustment transactions
+        transactions = await self._repo.find_with_filters(
+            source_filter="opening_balance_adjustment",
+        )
+
+        for txn in transactions:
+            txn_iban = normalize_iban(txn.get_metadata_raw("opening_balance_iban"))
+            txn_hash = txn.get_metadata_raw("transfer_identity_hash")
+
+            if txn_iban == normalized and txn_hash == transfer_hash:
+                return True
+
+        return False

--- a/services/backend/src/swen/application/services/__init__.py
+++ b/services/backend/src/swen/application/services/__init__.py
@@ -3,6 +3,9 @@
 from swen.application.services.bank_account_import_service import (
     BankAccountImportService,
 )
+from swen.application.services.opening_balance_adjustment_service import (
+    OpeningBalanceAdjustmentService,
+)
 from swen.application.services.transaction_import_service import (
     TransactionImportResult,
     TransactionImportService,
@@ -14,6 +17,7 @@ from swen.application.services.transfer_reconciliation_service import (
 
 __all__ = [
     "BankAccountImportService",
+    "OpeningBalanceAdjustmentService",
     "TransactionImportResult",
     "TransactionImportService",
     "TransferContext",

--- a/services/backend/src/swen/application/services/bank_account_import_service.py
+++ b/services/backend/src/swen/application/services/bank_account_import_service.py
@@ -12,8 +12,8 @@ from swen.domain.integration.entities import AccountMapping
 from swen.domain.shared.iban import normalize_iban
 
 if TYPE_CHECKING:
-    from swen.application.ports.identity import CurrentUser
     from swen.application.factories import RepositoryFactory
+    from swen.application.ports.identity import CurrentUser
     from swen.domain.accounting.repositories import AccountRepository
     from swen.domain.integration.repositories import AccountMappingRepository
 

--- a/services/backend/src/swen/application/services/opening_balance_adjustment_service.py
+++ b/services/backend/src/swen/application/services/opening_balance_adjustment_service.py
@@ -1,0 +1,146 @@
+"""Application service for creating opening balance adjustments.
+
+This service orchestrates the creation of opening balance adjustments when
+internal transfers are discovered that predate the counterparty account's
+opening balance date.
+
+The problem this solves:
+- Account A syncs first with transactions from date X onwards
+- Account A's opening balance is calculated correctly for date X
+- Account B syncs later with transactions going back to date Y (where Y < X)
+- Transfers from B to A between Y and X would double-count in A's balance
+- This service creates adjustment entries to correct A's opening balance
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, time, timezone
+from decimal import Decimal
+from typing import TYPE_CHECKING, Optional
+
+from swen.application.queries.integration import OpeningBalanceQuery
+from swen.domain.accounting.entities import Account
+from swen.domain.accounting.services import OpeningBalanceService
+from swen.domain.accounting.well_known_accounts import WellKnownAccounts
+
+if TYPE_CHECKING:
+    from swen.application.factories import RepositoryFactory
+    from swen.application.ports.identity import CurrentUser
+    from swen.domain.accounting.repositories import (
+        AccountRepository,
+        TransactionRepository,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class OpeningBalanceAdjustmentService:
+    """Application service for creating opening balance adjustments."""
+
+    def __init__(
+        self,
+        account_repository: AccountRepository,
+        transaction_repository: TransactionRepository,
+        opening_balance_query: OpeningBalanceQuery,
+        current_user: CurrentUser,
+    ):
+        self._account_repo = account_repository
+        self._transaction_repo = transaction_repository
+        self._ob_query = opening_balance_query
+        self._user_id = current_user.user_id
+        self._opening_balance_service = OpeningBalanceService()
+
+    @classmethod
+    def from_factory(
+        cls,
+        factory: RepositoryFactory,
+    ) -> OpeningBalanceAdjustmentService:
+        return cls(
+            account_repository=factory.account_repository(),
+            transaction_repository=factory.transaction_repository(),
+            opening_balance_query=OpeningBalanceQuery.from_factory(factory),
+            current_user=factory.current_user,
+        )
+
+    async def create_adjustment_if_needed(  # NOQA: PLR0913
+        self,
+        counterparty_account: Account,
+        counterparty_iban: str,
+        transfer_amount: Decimal,
+        transfer_date: date,
+        is_incoming_to_counterparty: bool,
+        transfer_hash: Optional[str] = None,
+    ) -> bool:
+        # Check idempotency - has this adjustment already been created?
+        if transfer_hash:
+            already_exists = await self._ob_query.adjustment_exists_for_transfer(
+                iban=counterparty_iban,
+                transfer_hash=transfer_hash,
+            )
+            if already_exists:
+                logger.debug(
+                    "Opening balance adjustment already exists for transfer %s",
+                    transfer_hash,
+                )
+                return False
+
+        # Get the opening balance equity account
+        equity_account = await self._account_repo.find_by_account_number(
+            WellKnownAccounts.OPENING_BALANCE_EQUITY,
+        )
+        if not equity_account:
+            logger.warning(
+                "Cannot create opening balance adjustment: equity account %s not found",
+                WellKnownAccounts.OPENING_BALANCE_EQUITY,
+            )
+            return False
+
+        # Determine adjustment direction:
+        # - Incoming transfer to counterparty: their OB already includes it,
+        #   so we need to REDUCE their OB (positive adjustment)
+        # - Outgoing transfer from counterparty: their OB doesn't include it,
+        #   so we need to INCREASE their OB (negative adjustment)
+        adjustment_amount = (
+            transfer_amount if is_incoming_to_counterparty else -transfer_amount
+        )
+
+        # Convert date to datetime for the transaction
+        adjustment_datetime = datetime.combine(
+            transfer_date,
+            time.min,
+            timezone.utc,
+        )
+
+        # Create the adjustment using the domain service
+        adjustment_txn = (
+            self._opening_balance_service.create_opening_balance_adjustment(
+                asset_account=counterparty_account,
+                opening_balance_account=equity_account,
+                adjustment_amount=adjustment_amount,
+                adjustment_date=adjustment_datetime,
+                iban=counterparty_iban,
+                user_id=self._user_id,
+                related_transfer_hash=transfer_hash,
+            )
+        )
+
+        if adjustment_txn is None:
+            logger.debug(
+                "No adjustment needed for transfer (amount was zero)",
+            )
+            return False
+
+        # Persist the adjustment
+        await self._transaction_repo.save(adjustment_txn)
+
+        direction = "incoming" if is_incoming_to_counterparty else "outgoing"
+        logger.info(
+            "Created opening balance adjustment of %s EUR for %s (%s transfer on %s)",
+            adjustment_amount,
+            counterparty_account.name,
+            direction,
+            transfer_date,
+        )
+
+        return True

--- a/services/backend/src/swen/domain/accounting/__init__.py
+++ b/services/backend/src/swen/domain/accounting/__init__.py
@@ -22,6 +22,9 @@ from swen.domain.accounting.services.account_balance_service import (
 from swen.domain.accounting.value_objects.category_code import CategoryCode
 from swen.domain.accounting.value_objects.money import Money
 
+# Well-known accounts
+from swen.domain.accounting.well_known_accounts import WellKnownAccounts
+
 __all__ = [
     # Value Objects
     "Money",
@@ -37,4 +40,6 @@ __all__ = [
     "TransactionRepository",
     # Domain Services
     "AccountBalanceService",
+    # Well-known accounts
+    "WellKnownAccounts",
 ]

--- a/services/backend/src/swen/domain/accounting/value_objects/transaction_source.py
+++ b/services/backend/src/swen/domain/accounting/value_objects/transaction_source.py
@@ -8,15 +8,12 @@ from enum import Enum
 
 
 class TransactionSource(str, Enum):
-    """Origin of the transaction.
-
-    Uses (str, Enum) for Python 3.10 compatibility (StrEnum is 3.11+).
-    The string inheritance allows direct JSON serialization.
-    """
+    """Origin of the transaction."""
 
     BANK_IMPORT = "bank_import"
     MANUAL = "manual"
     OPENING_BALANCE = "opening_balance"
+    OPENING_BALANCE_ADJUSTMENT = "opening_balance_adjustment"
     REVERSAL = "reversal"
 
     @classmethod

--- a/services/backend/src/swen/domain/accounting/well_known_accounts.py
+++ b/services/backend/src/swen/domain/accounting/well_known_accounts.py
@@ -1,0 +1,5 @@
+class WellKnownAccounts:
+    """Standard account numbers with special system meaning."""
+
+    # Equity account used for opening balance entries
+    OPENING_BALANCE_EQUITY = "2000"

--- a/services/backend/tests/unit/application/services/test_transfer_context.py
+++ b/services/backend/tests/unit/application/services/test_transfer_context.py
@@ -1,0 +1,224 @@
+"""Unit tests for TransferContext dataclass."""
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+from swen.application.services.transfer_reconciliation_service import TransferContext
+from swen.domain.accounting.entities import Account, AccountType
+from swen.domain.accounting.value_objects import Currency
+
+TEST_USER_ID = uuid4()
+
+
+class TestTransferContextIsPreOpeningBalance:
+    """Tests for TransferContext.is_pre_opening_balance method."""
+
+    @pytest.fixture
+    def asset_account(self) -> Account:
+        """Create a sample asset account."""
+        return Account(
+            name="Test Account",
+            account_type=AccountType.ASSET,
+            account_number="1000",
+            user_id=TEST_USER_ID,
+            default_currency=Currency("EUR"),
+        )
+
+    def test_returns_true_when_transaction_before_opening_balance(
+        self,
+        asset_account: Account,
+    ):
+        """Should return True when transaction date is before OB date."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=asset_account,
+            counterparty_opening_balance_date=date(2025, 1, 20),
+        )
+
+        # Transaction on 2025-01-15, OB on 2025-01-20
+        assert context.is_pre_opening_balance(date(2025, 1, 15)) is True
+
+    def test_returns_false_when_transaction_on_opening_balance_date(
+        self,
+        asset_account: Account,
+    ):
+        """Should return False when transaction date equals OB date."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=asset_account,
+            counterparty_opening_balance_date=date(2025, 1, 20),
+        )
+
+        # Transaction on same day as OB
+        assert context.is_pre_opening_balance(date(2025, 1, 20)) is False
+
+    def test_returns_false_when_transaction_after_opening_balance(
+        self,
+        asset_account: Account,
+    ):
+        """Should return False when transaction date is after OB date."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=asset_account,
+            counterparty_opening_balance_date=date(2025, 1, 20),
+        )
+
+        # Transaction after OB
+        assert context.is_pre_opening_balance(date(2025, 2, 1)) is False
+
+    def test_returns_false_when_no_opening_balance_date(
+        self,
+        asset_account: Account,
+    ):
+        """Should return False when counterparty has no opening balance."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=asset_account,
+            counterparty_opening_balance_date=None,  # No OB
+        )
+
+        assert context.is_pre_opening_balance(date(2025, 1, 15)) is False
+
+    def test_returns_false_for_external_counterparty(self):
+        """Should return False when there's no counterparty account."""
+        context = TransferContext.external_counterparty("DE89370400440532013000")
+
+        assert context.is_pre_opening_balance(date(2025, 1, 15)) is False
+
+    def test_returns_false_for_not_a_transfer(self):
+        """Should return False when there's no transfer context."""
+        context = TransferContext.not_a_transfer()
+
+        assert context.is_pre_opening_balance(date(2025, 1, 15)) is False
+
+
+class TestTransferContextProperties:
+    """Tests for TransferContext properties."""
+
+    @pytest.fixture
+    def asset_account(self) -> Account:
+        """Create a sample asset account."""
+        return Account(
+            name="Test Asset",
+            account_type=AccountType.ASSET,
+            account_number="1000",
+            user_id=TEST_USER_ID,
+            default_currency=Currency("EUR"),
+        )
+
+    @pytest.fixture
+    def liability_account(self) -> Account:
+        """Create a sample liability account."""
+        return Account(
+            name="Credit Card",
+            account_type=AccountType.LIABILITY,
+            account_number="2000",
+            user_id=TEST_USER_ID,
+            default_currency=Currency("EUR"),
+        )
+
+    def test_is_internal_transfer_true_with_counterparty_account(
+        self,
+        asset_account: Account,
+    ):
+        """Should be internal transfer when counterparty account exists."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=asset_account,
+        )
+
+        assert context.is_internal_transfer is True
+
+    def test_is_internal_transfer_false_without_counterparty_account(self):
+        """Should not be internal transfer when no counterparty account."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=None,
+        )
+
+        assert context.is_internal_transfer is False
+
+    def test_is_asset_transfer_true_for_asset_counterparty(
+        self,
+        asset_account: Account,
+    ):
+        """Should be asset transfer when counterparty is asset account."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=asset_account,
+        )
+
+        assert context.is_asset_transfer is True
+
+    def test_is_asset_transfer_false_for_liability_counterparty(
+        self,
+        liability_account: Account,
+    ):
+        """Should not be asset transfer when counterparty is liability."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=liability_account,
+        )
+
+        assert context.is_asset_transfer is False
+
+    def test_is_liability_transfer_true_for_liability_counterparty(
+        self,
+        liability_account: Account,
+    ):
+        """Should be liability transfer when counterparty is liability."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=liability_account,
+        )
+
+        assert context.is_liability_transfer is True
+
+    def test_can_reconcile_true_for_asset_transfer_with_iban(
+        self,
+        asset_account: Account,
+    ):
+        """Should be able to reconcile asset transfers with IBAN."""
+        context = TransferContext(
+            counterparty_iban="DE89370400440532013000",
+            counterparty_account=asset_account,
+        )
+
+        assert context.can_reconcile is True
+
+    def test_can_reconcile_false_without_iban(
+        self,
+        asset_account: Account,
+    ):
+        """Should not be able to reconcile without IBAN."""
+        context = TransferContext(
+            counterparty_iban=None,
+            counterparty_account=asset_account,
+        )
+
+        assert context.can_reconcile is False
+
+
+class TestTransferContextFactoryMethods:
+    """Tests for TransferContext factory methods."""
+
+    def test_not_a_transfer_returns_empty_context(self):
+        """Should return context with no counterparty info."""
+        context = TransferContext.not_a_transfer()
+
+        assert context.counterparty_iban is None
+        assert context.counterparty_account is None
+        assert context.counterparty_opening_balance_date is None
+        assert context.is_internal_transfer is False
+
+    def test_external_counterparty_returns_iban_only(self):
+        """Should return context with IBAN but no account."""
+        iban = "DE89370400440532013000"
+        context = TransferContext.external_counterparty(iban)
+
+        assert context.counterparty_iban == iban
+        assert context.counterparty_account is None
+        assert context.counterparty_opening_balance_date is None
+        assert context.is_internal_transfer is False

--- a/services/backend/tests/unit/domain/integration/test_transaction_import_service.py
+++ b/services/backend/tests/unit/domain/integration/test_transaction_import_service.py
@@ -6,11 +6,15 @@ from uuid import UUID
 import pytest
 
 from swen.application.factories import BankImportTransactionFactory
+from swen.application.ports.identity import CurrentUser
+from swen.application.queries.integration import OpeningBalanceQuery
 from swen.application.services import TransactionImportService
+from swen.application.services.opening_balance_adjustment_service import (
+    OpeningBalanceAdjustmentService,
+)
 from swen.application.services.transfer_reconciliation_service import (
     TransferReconciliationService,
 )
-from swen.application.ports.identity import CurrentUser
 
 TEST_USER_ID = UUID("12345678-1234-5678-1234-567812345678")
 
@@ -24,13 +28,22 @@ def service():
     mapping_repo = AsyncMock()
     current_user = CurrentUser(user_id=TEST_USER_ID, email="test@example.com")
 
+    ob_query = OpeningBalanceQuery(transaction_repository=transaction_repo)
     transfer_service = TransferReconciliationService(
         transaction_repository=transaction_repo,
         mapping_repository=mapping_repo,
         account_repository=account_repo,
+        opening_balance_query=ob_query,
     )
 
     transaction_factory = BankImportTransactionFactory(
+        current_user=current_user,
+    )
+
+    ob_adjustment_service = OpeningBalanceAdjustmentService(
+        account_repository=account_repo,
+        transaction_repository=transaction_repo,
+        opening_balance_query=ob_query,
         current_user=current_user,
     )
 
@@ -38,6 +51,7 @@ def service():
         bank_account_import_service=AsyncMock(),
         counter_account_resolution_service=AsyncMock(),
         transfer_reconciliation_service=transfer_service,
+        opening_balance_adjustment_service=ob_adjustment_service,
         transaction_factory=transaction_factory,
         account_repository=account_repo,
         transaction_repository=transaction_repo,

--- a/services/frontend/src/api/auth.ts
+++ b/services/frontend/src/api/auth.ts
@@ -11,7 +11,8 @@ export { tryRefreshToken as tryRefresh }
  * We only store the access token in memory.
  */
 export async function login(credentials: LoginRequest): Promise<AuthResponse> {
-  const response = await api.post<AuthResponse>('/auth/login', credentials)
+  // Skip auth refresh - login should show actual error, not "session expired"
+  const response = await api.post<AuthResponse>('/auth/login', credentials, { skipAuthRefresh: true })
   setAccessToken(response.access_token)
   return response
 }
@@ -23,7 +24,8 @@ export async function login(credentials: LoginRequest): Promise<AuthResponse> {
  * We only store the access token in memory.
  */
 export async function register(data: RegisterRequest): Promise<AuthResponse> {
-  const response = await api.post<AuthResponse>('/auth/register', data)
+  // Skip auth refresh - register should show actual error, not "session expired"
+  const response = await api.post<AuthResponse>('/auth/register', data, { skipAuthRefresh: true })
   setAccessToken(response.access_token)
   return response
 }


### PR DESCRIPTION
When importing long horizons, I encountered an issue that internal transfers were double booked. 

The fix creates **opening balance adjustments** for pre-opening-balance internal transfers. We did not need to make any changes to our core domain. We just added a service `OpeningBalanceAdjustmentService` and created one more `TransactionSource` for easier filtering.