### PR TITLE
[Refactor] Remove Business Logic from EditTransactionCommand 

### DIFF
--- a/services/backend/src/swen/application/accounting/commands/edit_transaction_command.py
+++ b/services/backend/src/swen/application/accounting/commands/edit_transaction_command.py
@@ -6,22 +6,17 @@ from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID
 
 from swen.domain.accounting.aggregates import Transaction
-from swen.domain.accounting.entities import Account
 from swen.domain.accounting.exceptions import (
     AccountNotFoundError,
     TransactionNotFoundError,
 )
 from swen.domain.accounting.repositories import AccountRepository, TransactionRepository
-from swen.domain.accounting.services import (
-    CATEGORY_ACCOUNT_TYPES,
-    PAYMENT_ACCOUNT_TYPES,
-    TransactionEntryService,
-)
-from swen.domain.accounting.value_objects import JournalEntryInput, MetadataKeys, Money
-from swen.domain.shared.exceptions import BusinessRuleViolation, ValidationError
+from swen.domain.accounting.services import TransactionEditService
+from swen.domain.accounting.value_objects import JournalEntryInput
 
 if TYPE_CHECKING:
     from swen.application.factories import RepositoryFactory
+    from swen.domain.accounting.entities import Account
 
 
 class EditTransactionCommand:
@@ -42,53 +37,64 @@ class EditTransactionCommand:
             account_repository=factory.account_repository(),
         )
 
+    async def _update_with_new_entries(
+        self,
+        transaction: Transaction,
+        entries: list[JournalEntryInput],
+    ):
+        account_ids = {entry.account_id for entry in entries}
+        accounts = await self._load_accounts(account_ids)
+        TransactionEditService.replace_entries(transaction, entries, accounts)
+
+    async def _update_with_new_counter_account(
+        self,
+        transaction: Transaction,
+        counter_account_id: UUID,
+    ):
+        accounts = await self._load_accounts({counter_account_id})
+        counter_account = accounts[counter_account_id]
+        TransactionEditService.change_counter_account(transaction, counter_account)
+
     async def execute(  # NOQA: PLR0913
         self,
         transaction_id: UUID,
         entries: Optional[list[JournalEntryInput]] = None,
-        category_account_id: Optional[UUID] = None,
+        counter_account_id: Optional[UUID] = None,
         description: Optional[str] = None,
         counterparty: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         repost: bool = False,
     ) -> Transaction:
         # Validate mutually exclusive parameters
-        if entries is not None and category_account_id is not None:
+        if entries is not None and counter_account_id is not None:
             msg = (
-                "Cannot specify both 'entries' and 'category_account_id'. "
+                "Cannot specify both 'entries' and 'counter_account_id'. "
                 "Use 'entries' for full entry replacement or "
-                "'category_account_id' for simple category swap."
+                "'counter_account_id' for simple counter-account swap."
             )
-            raise ValidationError(msg)
+            raise ValueError(msg)
 
-        # Load transaction
         transaction = await self._load_transaction(transaction_id)
+        was_posted = self._unpost_if_needed(transaction)  # to be able to edit
 
-        # Unpost if needed (cross-cutting concern)
-        was_posted = self._unpost_if_needed(transaction)
-
-        # Route to operations based on inputs
         if entries is not None:
-            await self._replace_entries(transaction, entries)
-        elif category_account_id is not None:
-            await self._change_category(transaction, category_account_id)
+            await self._update_with_new_entries(transaction, entries)
+        elif counter_account_id is not None:
+            await self._update_with_new_counter_account(transaction, counter_account_id)
 
         if description is not None:
-            self._update_description(transaction, description)
-
+            transaction.update_description(description)
         if counterparty is not None:
-            self._update_counterparty(transaction, counterparty)
-
+            transaction.update_counterparty(counterparty)
         if metadata is not None:
-            self._update_metadata(transaction, metadata)
+            TransactionEditService.update_metadata(transaction, metadata)
 
-        # Repost if requested and was originally posted (cross-cutting concern)
+        # Repost if requested and was originally posted
         if repost and was_posted:
             transaction.post()
 
-        # Save changes (cross-cutting concern)
+        # Persist changes
         await self._transaction_repo.save(transaction)
-
         return transaction
 
     async def _load_transaction(self, transaction_id: UUID) -> Transaction:
@@ -116,128 +122,3 @@ class EditTransactionCommand:
             accounts[account_id] = account
 
         return accounts
-
-    async def _replace_entries(
-        self,
-        transaction: Transaction,
-        entries: list[JournalEntryInput],
-    ):
-        # Load all referenced accounts
-        account_ids = {entry.account_id for entry in entries}
-        accounts = await self._load_accounts(account_ids)
-
-        # Clear existing entries (preserves protected entries for bank imports)
-        transaction.clear_entries()
-
-        # Count protected entries that were preserved
-        protected_count = len(transaction.protected_entries)
-
-        # Validate minimum entries after considering protected ones
-        min_entries = 2
-        total_entries = protected_count + len(entries)
-        if total_entries < min_entries:
-            msg = (
-                f"Transaction must have at least {min_entries} entries, "
-                f"got {total_entries} (including {protected_count} protected)"
-            )
-            raise ValidationError(msg)
-
-        # Add new entries
-        for entry_input in entries:
-            account = accounts[entry_input.account_id]
-            money = Money(entry_input.amount, account.default_currency)
-
-            if entry_input.is_debit:
-                transaction.add_debit(account, money)
-            else:
-                transaction.add_credit(account, money)
-
-    async def _change_category(
-        self,
-        transaction: Transaction,
-        new_category_id: UUID,
-    ):
-        new_category = await self._account_repo.find_by_id(new_category_id)
-        if not new_category:
-            raise AccountNotFoundError(account_id=new_category_id)
-
-        current_category_entry = None
-        payment_entry = None
-
-        for entry in transaction.entries:
-            if entry.account.account_type in CATEGORY_ACCOUNT_TYPES:
-                current_category_entry = entry
-            elif entry.account.account_type in PAYMENT_ACCOUNT_TYPES:
-                payment_entry = entry
-
-        if not current_category_entry or not payment_entry:
-            msg = (
-                "Transaction does not have the expected structure "
-                "(category + asset/liability). "
-                "Use 'entries' parameter for multi-entry transactions."
-            )
-            raise BusinessRuleViolation(msg)
-
-        # Get the amount from the current category entry
-        amount = (
-            current_category_entry.debit
-            if current_category_entry.is_debit()
-            else current_category_entry.credit
-        )
-
-        # Clear unprotected entries (preserves payment entry for bank imports)
-        transaction.clear_entries()
-
-        # Check if payment entry was preserved (bank import case)
-        payment_preserved = any(
-            e.account.account_type in PAYMENT_ACCOUNT_TYPES for e in transaction.entries
-        )
-
-        # Use domain service to build the new entries
-        # InvalidAccountTypeError is raised by the service if new_category is invalid
-        entry_specs = TransactionEntryService.build_category_swap_entries(
-            new_category=new_category,
-            payment_account=payment_entry.account,
-            amount=amount,
-            payment_preserved=payment_preserved,
-        )
-
-        # Apply the entry specifications to the transaction
-        for spec in entry_specs:
-            if spec.is_debit:
-                transaction.add_debit(spec.account, spec.amount)
-            else:
-                transaction.add_credit(spec.account, spec.amount)
-
-    def _update_description(
-        self,
-        transaction: Transaction,
-        description: str,
-    ):
-        transaction.update_description(description)
-
-    def _update_counterparty(
-        self,
-        transaction: Transaction,
-        counterparty: str,
-    ):
-        transaction.update_counterparty(counterparty)
-
-    def _update_metadata(
-        self,
-        transaction: Transaction,
-        metadata: dict[str, Any],
-    ):
-        # Check for reserved keys
-        reserved_in_update = set(metadata.keys()) & MetadataKeys.RESERVED_KEYS
-        if reserved_in_update:
-            reserved_list = ", ".join(sorted(reserved_in_update))
-            msg = (
-                f"Cannot modify reserved metadata keys via raw update: {reserved_list}."
-                " Use transaction.update_metadata() for typed field updates."
-            )
-            raise ValidationError(msg)
-
-        # Apply non-reserved metadata
-        for key, value in metadata.items():
-            transaction.set_metadata_raw(key, value)

--- a/services/backend/src/swen/application/accounting/dtos/transaction_list_dto.py
+++ b/services/backend/src/swen/application/accounting/dtos/transaction_list_dto.py
@@ -7,11 +7,7 @@ from typing import Optional
 from uuid import UUID
 
 from swen.domain.accounting.aggregates import Transaction
-from swen.domain.accounting.entities import JournalEntry
-from swen.domain.accounting.entities.account_type import AccountType
-
-# Account types that represent payment accounts (bank accounts, credit cards)
-PAYMENT_ACCOUNT_TYPES = frozenset({AccountType.ASSET, AccountType.LIABILITY})
+from swen.domain.accounting.entities import PAYMENT_ACCOUNT_TYPES, JournalEntry
 
 
 @dataclass(frozen=True)

--- a/services/backend/src/swen/domain/accounting/entities/__init__.py
+++ b/services/backend/src/swen/domain/accounting/entities/__init__.py
@@ -1,7 +1,17 @@
 """Domain entities for the accounting bounded context."""
 
 from swen.domain.accounting.entities.account import Account
-from swen.domain.accounting.entities.account_type import AccountType
+from swen.domain.accounting.entities.account_type import (
+    CATEGORY_ACCOUNT_TYPES,
+    PAYMENT_ACCOUNT_TYPES,
+    AccountType,
+)
 from swen.domain.accounting.entities.journal_entry import JournalEntry
 
-__all__ = ["Account", "AccountType", "JournalEntry"]
+__all__ = [
+    "Account",
+    "AccountType",
+    "JournalEntry",
+    "CATEGORY_ACCOUNT_TYPES",
+    "PAYMENT_ACCOUNT_TYPES",
+]

--- a/services/backend/src/swen/domain/accounting/entities/account_type.py
+++ b/services/backend/src/swen/domain/accounting/entities/account_type.py
@@ -14,3 +14,7 @@ class AccountType(Enum):
 
     def is_debit_normal(self) -> bool:
         return self in (AccountType.ASSET, AccountType.EXPENSE)
+
+
+PAYMENT_ACCOUNT_TYPES = frozenset({AccountType.ASSET, AccountType.LIABILITY})
+CATEGORY_ACCOUNT_TYPES = frozenset({AccountType.EXPENSE, AccountType.INCOME})

--- a/services/backend/src/swen/domain/accounting/services/__init__.py
+++ b/services/backend/src/swen/domain/accounting/services/__init__.py
@@ -13,9 +13,10 @@ from swen.domain.accounting.services.opening_balance import (
     OpeningBalanceCalculator,
     OpeningBalanceService,
 )
+from swen.domain.accounting.services.transaction_edit_service import (
+    TransactionEditService,
+)
 from swen.domain.accounting.services.transaction_entry_service import (
-    CATEGORY_ACCOUNT_TYPES,
-    PAYMENT_ACCOUNT_TYPES,
     EntrySpec,
     TransactionDirection,
     TransactionEntryService,
@@ -25,13 +26,12 @@ from swen.domain.accounting.value_objects import MetadataKeys
 __all__ = [
     "AccountBalanceService",
     "AccountHierarchyService",
-    "CATEGORY_ACCOUNT_TYPES",
     "ClassificationRules",
     "EntrySpec",
     "MetadataKeys",
     "OpeningBalanceCalculator",
     "OpeningBalanceService",
-    "PAYMENT_ACCOUNT_TYPES",
     "TransactionDirection",
+    "TransactionEditService",
     "TransactionEntryService",
 ]

--- a/services/backend/src/swen/domain/accounting/services/transaction_edit_service.py
+++ b/services/backend/src/swen/domain/accounting/services/transaction_edit_service.py
@@ -1,0 +1,159 @@
+"""Domain service for editing existing transactions.
+
+This domain service encapsulates the business rules for editing transactions,
+including:
+- Replacing entries (with protected-entry preservation for bank imports)
+- Recategorizing transactions (validating structure, swapping category)
+- Metadata updates (enforcing reserved key constraints)
+
+It operates purely on the Transaction aggregate and Account entities,
+delegating entry building to TransactionEntryService where appropriate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from swen.domain.accounting.aggregates import Transaction
+from swen.domain.accounting.entities import Account
+from swen.domain.accounting.services.transaction_entry_service import (
+    CATEGORY_ACCOUNT_TYPES,
+    PAYMENT_ACCOUNT_TYPES,
+    TransactionEntryService,
+)
+from swen.domain.accounting.value_objects import (
+    JournalEntryInput,
+    MetadataKeys,
+    Money,
+)
+from swen.domain.shared.exceptions import BusinessRuleViolation, ValidationError
+
+
+class TransactionEditService:
+    """Domain service for editing existing transactions.
+
+    This service encapsulates the business rules for transaction editing.
+    It is stateless and operates purely on the provided domain objects.
+    """
+
+    @staticmethod
+    def replace_entries(
+        transaction: Transaction,
+        entries: list[JournalEntryInput],
+        accounts: dict[UUID, Account],
+    ) -> None:
+        """Replace transaction entries with new ones.
+
+        Business rules:
+        - Bank imports preserve protected (asset) entries
+        - Minimum 2 entries required after considering protected ones
+        """
+        # Clear existing entries (preserves protected entries for bank imports)
+        transaction.clear_entries()
+
+        # Count protected entries that were preserved
+        protected_count = len(transaction.protected_entries)
+
+        # Validate minimum entries after considering protected ones
+        min_entries = 2
+        total_entries = protected_count + len(entries)
+        if total_entries < min_entries:
+            msg = (
+                f"Transaction must have at least {min_entries} entries, "
+                f"got {total_entries} (including {protected_count} protected)"
+            )
+            raise ValidationError(msg)
+
+        # Add new entries
+        for entry_input in entries:
+            account = accounts[entry_input.account_id]
+            money = Money(entry_input.amount, account.default_currency)
+
+            if entry_input.is_debit:
+                transaction.add_debit(account, money)
+            else:
+                transaction.add_credit(account, money)
+
+    @staticmethod
+    def change_counter_account(
+        transaction: Transaction,
+        counter_account: Account,
+    ) -> None:
+        """Recategorize a transaction.
+
+        Business rules:
+        - Transaction must have exactly one category + one payment entry
+        - New category must match transaction direction (expense/income)
+        - Bank imports preserve the payment entry
+        """
+        current_category_entry = None
+        payment_entry = None
+
+        for entry in transaction.entries:
+            if entry.account.account_type in CATEGORY_ACCOUNT_TYPES:
+                current_category_entry = entry
+            elif entry.account.account_type in PAYMENT_ACCOUNT_TYPES:
+                payment_entry = entry
+
+        if not current_category_entry or not payment_entry:
+            msg = (
+                "Transaction does not have the expected structure "
+                "(category + asset/liability). "
+                "Use 'entries' parameter for multi-entry transactions."
+            )
+            raise BusinessRuleViolation(msg)
+
+        # Get the amount from the current category entry
+        amount = (
+            current_category_entry.debit
+            if current_category_entry.is_debit()
+            else current_category_entry.credit
+        )
+
+        # Clear unprotected entries (preserves payment entry for bank imports)
+        transaction.clear_entries()
+
+        # Check if payment entry was preserved (bank import case)
+        payment_preserved = any(
+            e.account.account_type in PAYMENT_ACCOUNT_TYPES for e in transaction.entries
+        )
+
+        # Use domain service to build the new entries
+        entry_specs = TransactionEntryService.build_category_swap_entries(
+            new_category=counter_account,
+            payment_account=payment_entry.account,
+            amount=amount,
+            payment_preserved=payment_preserved,
+        )
+
+        # Apply the entry specifications to the transaction
+        for spec in entry_specs:
+            if spec.is_debit:
+                transaction.add_debit(spec.account, spec.amount)
+            else:
+                transaction.add_credit(spec.account, spec.amount)
+
+    @staticmethod
+    def update_metadata(
+        transaction: Transaction,
+        metadata: dict[str, Any],
+    ) -> None:
+        """Update metadata with reserved-key enforcement.
+
+        Business rules:
+        - Reserved keys cannot be modified via raw update
+        """
+        # Check for reserved keys
+        reserved_in_update = set(metadata.keys()) & MetadataKeys.RESERVED_KEYS
+        if reserved_in_update:
+            reserved_list = ", ".join(sorted(reserved_in_update))
+            msg = (
+                f"Cannot modify reserved metadata keys via raw update: {reserved_list}."
+                " Use transaction.update_metadata() for typed field updates."
+            )
+            raise ValidationError(msg)
+
+        # Apply non-reserved metadata
+        for key, value in metadata.items():
+            transaction.set_metadata_raw(key, value)

--- a/services/backend/src/swen/domain/accounting/services/transaction_entry_service.py
+++ b/services/backend/src/swen/domain/accounting/services/transaction_entry_service.py
@@ -19,7 +19,12 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Tuple
 
-from swen.domain.accounting.entities import Account, AccountType
+from swen.domain.accounting.entities import (
+    CATEGORY_ACCOUNT_TYPES,
+    PAYMENT_ACCOUNT_TYPES,
+    Account,
+    AccountType,
+)
 from swen.domain.accounting.exceptions import InvalidAccountTypeError
 from swen.domain.accounting.value_objects import (
     JournalEntryInput,
@@ -56,10 +61,6 @@ class EntrySpec:
     def __repr__(self) -> str:
         side = "Dr" if self.is_debit else "Cr"
         return f"{side} {self.account.name} {self.amount}"
-
-
-PAYMENT_ACCOUNT_TYPES = frozenset({AccountType.ASSET, AccountType.LIABILITY})
-CATEGORY_ACCOUNT_TYPES = frozenset({AccountType.EXPENSE, AccountType.INCOME})
 
 
 class TransactionEntryService:

--- a/services/backend/src/swen/domain/integration/services/transfer_reconciliation_service.py
+++ b/services/backend/src/swen/domain/integration/services/transfer_reconciliation_service.py
@@ -10,11 +10,13 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from swen.domain.accounting.aggregates import Transaction
-from swen.domain.accounting.entities import Account, AccountType, JournalEntry
-from swen.domain.accounting.services import (
+from swen.domain.accounting.entities import (
     CATEGORY_ACCOUNT_TYPES,
-    TransactionEntryService,
+    Account,
+    AccountType,
+    JournalEntry,
 )
+from swen.domain.accounting.services import TransactionEntryService
 from swen.domain.accounting.value_objects import MetadataKeys
 from swen.domain.banking.value_objects import BankTransaction
 

--- a/services/backend/src/swen/presentation/api/accounting/routers/transactions.py
+++ b/services/backend/src/swen/presentation/api/accounting/routers/transactions.py
@@ -422,10 +422,10 @@ async def update_transaction(
     You can update:
     - **description**: Change the transaction description
     - **counterparty**: Change the merchant/payer name
-    - **category_account_id**: Re-categorize to a different expense/income account
+    - **counter_account_id**: Re-categorize to a different expense/income account
     - **entries**: Replace all journal entries (for splitting, amount changes, etc.)
 
-    Note: `entries` and `category_account_id` are mutually exclusive.
+    Note: `entries` and `counter_account_id` are mutually exclusive.
 
     If the transaction is posted and `repost=True` (default), it will be
     automatically unposted, modified, and re-posted.
@@ -443,7 +443,7 @@ async def update_transaction(
             entries=entry_inputs,
             description=request.description,
             counterparty=request.counterparty,
-            category_account_id=request.category_account_id,
+            counter_account_id=request.counter_account_id,
             repost=request.repost,
         )
         await factory.session.commit()

--- a/services/backend/src/swen/presentation/api/accounting/schemas/transactions.py
+++ b/services/backend/src/swen/presentation/api/accounting/schemas/transactions.py
@@ -309,16 +309,16 @@ class TransactionUpdateRequest(BaseModel):
     Use `entries` for full replacement of journal entries. This is for
     advanced editing like splitting transactions or correcting amounts.
 
-    **Category Change**:
-    Use `category_account_id` for simple re-categorization (swapping the
+    **Counter Account Change**:
+    Use `counter_account_id` for simple re-categorization (swapping the
     expense/income account while keeping the same amount).
 
-    Note: `entries` and `category_account_id` are mutually exclusive.
+    Note: `entries` and `counter_account_id` are mutually exclusive.
     """
 
     description: Optional[str] = Field(None, min_length=1, max_length=500)
     counterparty: Optional[str] = Field(None, max_length=200)
-    category_account_id: Optional[UUID] = None
+    counter_account_id: Optional[UUID] = None
     entries: Optional[list[JournalEntryRequest]] = Field(None, min_length=1)
     repost: bool = True
 
@@ -328,7 +328,7 @@ class TransactionUpdateRequest(BaseModel):
                 {
                     "summary": "Simple re-categorization",
                     "value": {
-                        "category_account_id": "660e8400-e29b-41d4-a716-446655440001",
+                        "counter_account_id": "660e8400-e29b-41d4-a716-446655440001",
                         "repost": True,
                     },
                 },

--- a/services/backend/tests/cross_domain/e2e/test_cash_transaction_journey.py
+++ b/services/backend/tests/cross_domain/e2e/test_cash_transaction_journey.py
@@ -271,12 +271,12 @@ class TestManualTransactionEditing:
         )
         txn_id = create_response.json()["id"]
 
-        # Recategorize using category_account_id shortcut
+        # Recategorize using counter_account_id shortcut
         update_response = test_client.put(
             f"{api_v1_prefix}/transactions/{txn_id}",
             headers=headers,
             json={
-                "category_account_id": expense2["id"],
+                "counter_account_id": expense2["id"],
             },
         )
         assert update_response.status_code == 200

--- a/services/backend/tests/swen/integration/ai/test_ml_integration.py
+++ b/services/backend/tests/swen/integration/ai/test_ml_integration.py
@@ -337,7 +337,7 @@ class TestTransactionPosting:
                 f"{api_v1_prefix}/transactions/{transaction_id}",
                 headers=headers,
                 json={
-                    "category_account_id": new_expense_id,
+                    "counter_account_id": new_expense_id,
                 },
             )
 

--- a/services/backend/tests/swen/unit/application/commands/test_edit_transaction_command.py
+++ b/services/backend/tests/swen/unit/application/commands/test_edit_transaction_command.py
@@ -1,7 +1,11 @@
 """Unit tests for EditTransactionCommand."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -14,6 +18,16 @@ from swen.domain.accounting.exceptions import (
 )
 from swen.domain.accounting.value_objects import Currency, JournalEntryInput, Money
 from swen.domain.shared.exceptions import ValidationError
+
+
+@dataclass
+class DomainCallTracker:
+    """Tracks calls to domain service methods."""
+
+    replace_count: int = 0
+    change_count: int = 0
+    metadata_count: int = 0
+    metadata_applied: dict[str, Any] = field(default_factory=dict)
 
 
 @pytest.fixture
@@ -116,41 +130,34 @@ def mock_account_repo(mock_account) -> AsyncMock:
 class TestEditTransactionCommand:
     """Tests for EditTransactionCommand coordinator."""
 
-    @pytest.fixture
-    def command(
+    async def test_load_transaction_not_found(
         self,
         mock_transaction_repo,
         mock_account_repo,
-    ) -> EditTransactionCommand:
-        """Create command under test."""
-        return EditTransactionCommand(
-            transaction_repository=mock_transaction_repo,
-            account_repository=mock_account_repo,
-        )
-
-    # =========================================================================
-    # Coordinator tests
-    # =========================================================================
-
-    async def test_load_transaction_not_found(
-        self,
-        command,
-        mock_transaction_repo,
     ):
         """Raises TransactionNotFoundError when transaction doesn't exist."""
         mock_transaction_repo.find_by_id.return_value = None
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
         with pytest.raises(TransactionNotFoundError):
             await command.execute(transaction_id=uuid4())
 
     async def test_unpost_if_posted(
         self,
-        command,
         mock_transaction_repo,
+        mock_account_repo,
     ):
         """Transaction is unposted before edits if it was posted."""
         txn = mock_transaction_repo._transaction
         txn.is_posted = True
+
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
         await command.execute(
             transaction_id=txn.id,
@@ -162,12 +169,17 @@ class TestEditTransactionCommand:
 
     async def test_repost_if_was_posted_and_requested(
         self,
-        command,
         mock_transaction_repo,
+        mock_account_repo,
     ):
         """Transaction is reposted after edits if it was posted and repost=True."""
         txn = mock_transaction_repo._transaction
         txn.is_posted = True
+
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
         await command.execute(
             transaction_id=txn.id,
@@ -180,11 +192,16 @@ class TestEditTransactionCommand:
 
     async def test_save_is_called(
         self,
-        command,
         mock_transaction_repo,
+        mock_account_repo,
     ):
         """Transaction is saved after edits."""
         txn = mock_transaction_repo._transaction
+
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
         await command.execute(
             transaction_id=txn.id,
@@ -195,14 +212,17 @@ class TestEditTransactionCommand:
 
     async def test_entries_and_category_mutually_exclusive(
         self,
-        command,
         mock_transaction_repo,
         mock_account_repo,
     ):
-        """Cannot specify both entries and category_account_id."""
+        """Cannot specify both entries and counter_account_id."""
         txn = mock_transaction_repo._transaction
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             await command.execute(
                 transaction_id=txn.id,
                 entries=[
@@ -215,7 +235,7 @@ class TestEditTransactionCommand:
                         Decimal("50.00"),
                     ),
                 ],
-                category_account_id=mock_account_repo._expense_account2.id,
+                counter_account_id=mock_account_repo._expense_account2.id,
             )
 
         assert "cannot specify both" in str(exc_info.value).lower()
@@ -226,11 +246,16 @@ class TestEditTransactionCommand:
 
     async def test_update_description(
         self,
-        command,
         mock_transaction_repo,
+        mock_account_repo,
     ):
         """Description is updated via transaction method."""
         txn = mock_transaction_repo._transaction
+
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
         await command.execute(
             transaction_id=txn.id,
@@ -245,11 +270,16 @@ class TestEditTransactionCommand:
 
     async def test_update_counterparty(
         self,
-        command,
         mock_transaction_repo,
+        mock_account_repo,
     ):
         """Counterparty is updated via transaction method."""
         txn = mock_transaction_repo._transaction
+
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
         await command.execute(
             transaction_id=txn.id,
@@ -264,26 +294,46 @@ class TestEditTransactionCommand:
 
     async def test_update_metadata(
         self,
-        command,
         mock_transaction_repo,
+        mock_account_repo,
     ):
-        """Metadata is updated via transaction method."""
+        """Metadata is updated via domain service."""
         txn = mock_transaction_repo._transaction
+        tracker = DomainCallTracker()
 
-        await command.execute(
-            transaction_id=txn.id,
-            metadata={"custom_tag": "value123"},
-        )
+        def mock_update_metadata(transaction, metadata):
+            tracker.metadata_count += 1
+            tracker.metadata_applied.update(metadata)
 
-        txn.set_metadata_raw.assert_called_once_with("custom_tag", "value123")
+        with patch(
+            "swen.application.accounting.commands.edit_transaction_command.TransactionEditService.update_metadata",
+            staticmethod(mock_update_metadata),
+        ):
+            command = EditTransactionCommand(
+                transaction_repository=mock_transaction_repo,
+                account_repository=mock_account_repo,
+            )
+
+            await command.execute(
+                transaction_id=txn.id,
+                metadata={"custom_tag": "value123"},
+            )
+
+        assert tracker.metadata_count == 1
+        assert tracker.metadata_applied.get("custom_tag") == "value123"
 
     async def test_update_metadata_rejects_reserved_keys(
         self,
-        command,
         mock_transaction_repo,
+        mock_account_repo,
     ):
-        """Reserved metadata keys are rejected."""
+        """Reserved metadata keys are rejected by domain service."""
         txn = mock_transaction_repo._transaction
+
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
         with pytest.raises(ValidationError) as exc_info:
             await command.execute(
@@ -299,69 +349,97 @@ class TestEditTransactionCommand:
 
     async def test_replace_entries(
         self,
-        command,
         mock_transaction_repo,
         mock_account_repo,
     ):
-        """Entries are replaced via clear + add."""
+        """Entries are replaced via domain service."""
         txn = mock_transaction_repo._transaction
-        asset = mock_account_repo._asset_account
-        expense = mock_account_repo._expense_account
+        tracker = DomainCallTracker()
 
-        entries = [
-            JournalEntryInput.debit_entry(expense.id, Decimal("75.00")),
-            JournalEntryInput.credit_entry(asset.id, Decimal("75.00")),
-        ]
+        def mock_replace_entries(transaction, entries, accounts):
+            tracker.replace_count += 1
 
-        await command.execute(
-            transaction_id=txn.id,
-            entries=entries,
-        )
+        with patch(
+            "swen.application.accounting.commands.edit_transaction_command.TransactionEditService.replace_entries",
+            staticmethod(mock_replace_entries),
+        ):
+            command = EditTransactionCommand(
+                transaction_repository=mock_transaction_repo,
+                account_repository=mock_account_repo,
+            )
 
-        txn.clear_entries.assert_called_once()
-        assert txn.add_debit.call_count == 1
-        assert txn.add_credit.call_count == 1
+            entries = [
+                JournalEntryInput.debit_entry(
+                    mock_account_repo._expense_account.id, Decimal("75.00")
+                ),
+                JournalEntryInput.credit_entry(
+                    mock_account_repo._asset_account.id, Decimal("75.00")
+                ),
+            ]
+
+            await command.execute(
+                transaction_id=txn.id,
+                entries=entries,
+            )
+
+        assert tracker.replace_count == 1
 
     async def test_replace_entries_with_multiple(
         self,
-        command,
         mock_transaction_repo,
         mock_account_repo,
     ):
         """Multi-entry replacement works (split transaction)."""
         txn = mock_transaction_repo._transaction
-        asset = mock_account_repo._asset_account
-        expense1 = mock_account_repo._expense_account
-        expense2 = mock_account_repo._expense_account2
+        tracker = DomainCallTracker()
 
-        entries = [
-            JournalEntryInput.debit_entry(expense1.id, Decimal("30.00")),
-            JournalEntryInput.debit_entry(expense2.id, Decimal("20.00")),
-            JournalEntryInput.credit_entry(asset.id, Decimal("50.00")),
-        ]
+        def mock_replace_entries(transaction, entries, accounts):
+            tracker.replace_count += 1
 
-        await command.execute(
-            transaction_id=txn.id,
-            entries=entries,
-        )
+        with patch(
+            "swen.application.accounting.commands.edit_transaction_command.TransactionEditService.replace_entries",
+            staticmethod(mock_replace_entries),
+        ):
+            command = EditTransactionCommand(
+                transaction_repository=mock_transaction_repo,
+                account_repository=mock_account_repo,
+            )
 
-        txn.clear_entries.assert_called_once()
-        assert txn.add_debit.call_count == 2
-        assert txn.add_credit.call_count == 1
+            entries = [
+                JournalEntryInput.debit_entry(
+                    mock_account_repo._expense_account.id, Decimal("30.00")
+                ),
+                JournalEntryInput.debit_entry(
+                    mock_account_repo._expense_account2.id, Decimal("20.00")
+                ),
+                JournalEntryInput.credit_entry(
+                    mock_account_repo._asset_account.id, Decimal("50.00")
+                ),
+            ]
+
+            await command.execute(
+                transaction_id=txn.id,
+                entries=entries,
+            )
+
+        assert tracker.replace_count == 1
 
     async def test_replace_entries_requires_minimum_two(
         self,
-        command,
         mock_transaction_repo,
         mock_account_repo,
     ):
-        """At least 2 entries required."""
+        """At least 2 entries required - validated by domain service."""
         txn = mock_transaction_repo._transaction
+
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
         entries = [
             JournalEntryInput.debit_entry(
-                mock_account_repo._expense_account.id,
-                Decimal("50.00"),
+                mock_account_repo._expense_account.id, Decimal("50.00")
             ),
         ]
 
@@ -375,12 +453,17 @@ class TestEditTransactionCommand:
 
     async def test_replace_entries_account_not_found(
         self,
-        command,
         mock_transaction_repo,
+        mock_account_repo,
     ):
-        """Raises AccountNotFoundError for unknown account in entries."""
+        """Raises AccountNotFoundError for unknown account."""
         txn = mock_transaction_repo._transaction
         fake_id = uuid4()
+
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
 
         entries = [
             JournalEntryInput.debit_entry(fake_id, Decimal("50.00")),
@@ -394,35 +477,45 @@ class TestEditTransactionCommand:
             )
 
     # =========================================================================
-    # _change_category tests
+    # _change_counter_account tests
     # =========================================================================
 
-    async def test_change_category(
+    async def test_change_counter_account(
         self,
-        command,
         mock_transaction_repo,
         mock_account_repo,
     ):
-        """Category change swaps expense/income account."""
+        """Category change delegates to domain service."""
         txn = mock_transaction_repo._transaction
-        new_expense = mock_account_repo._expense_account2
+        tracker = DomainCallTracker()
 
-        await command.execute(
-            transaction_id=txn.id,
-            category_account_id=new_expense.id,
-        )
+        def mock_change_counter_account(transaction, counter_account):
+            tracker.change_count += 1
 
-        txn.clear_entries.assert_called_once()
-        # Should add new entries with the new category
-        assert txn.add_debit.call_count >= 1 or txn.add_credit.call_count >= 1
+        with patch(
+            "swen.application.accounting.commands.edit_transaction_command.TransactionEditService.change_counter_account",
+            staticmethod(mock_change_counter_account),
+        ):
+            command = EditTransactionCommand(
+                transaction_repository=mock_transaction_repo,
+                account_repository=mock_account_repo,
+            )
 
-    async def test_change_category_with_liability_account(
+            await command.execute(
+                transaction_id=txn.id,
+                counter_account_id=mock_account_repo._expense_account2.id,
+            )
+
+        assert tracker.change_count == 1
+
+    async def test_change_counter_account_with_liability_account(
         self,
+        mock_transaction_repo,
         mock_account_repo,
         mock_account,
     ):
         """Category change works when payment account is a liability (credit card)."""
-        # Create a liability account (credit card)
+        # Create a liability account
         liability_account = mock_account(AccountType.LIABILITY, "Credit Card")
         expense_account = mock_account(AccountType.EXPENSE, "Groceries")
         new_expense_account = mock_account(AccountType.EXPENSE, "Restaurant")
@@ -459,36 +552,48 @@ class TestEditTransactionCommand:
         txn_repo.find_by_id = AsyncMock(return_value=txn)
         txn_repo.save = AsyncMock()
 
-        # Create command
-        command = EditTransactionCommand(
-            transaction_repository=txn_repo,
-            account_repository=mock_account_repo,
-        )
+        tracker = DomainCallTracker()
 
-        # Execute category change - should NOT raise BusinessRuleViolation
-        await command.execute(
-            transaction_id=txn.id,
-            category_account_id=new_expense_account.id,
-        )
+        def mock_change_counter_account(transaction, counter_account):
+            tracker.change_count += 1
+
+        with patch(
+            "swen.application.accounting.commands.edit_transaction_command.TransactionEditService.change_counter_account",
+            staticmethod(mock_change_counter_account),
+        ):
+            command = EditTransactionCommand(
+                transaction_repository=txn_repo,
+                account_repository=mock_account_repo,
+            )
+
+            # Execute category change - should NOT raise BusinessRuleViolation
+            await command.execute(
+                transaction_id=txn.id,
+                counter_account_id=new_expense_account.id,
+            )
 
         # Verify the transaction was modified
-        txn.clear_entries.assert_called_once()
-        assert txn.add_debit.call_count >= 1 or txn.add_credit.call_count >= 1
+        assert tracker.change_count == 1
         txn_repo.save.assert_called_once_with(txn)
 
-    async def test_change_category_account_not_found(
+    async def test_change_counter_account_account_not_found(
         self,
-        command,
         mock_transaction_repo,
+        mock_account_repo,
     ):
         """Raises AccountNotFoundError for unknown category account."""
         txn = mock_transaction_repo._transaction
         fake_id = uuid4()
 
+        command = EditTransactionCommand(
+            transaction_repository=mock_transaction_repo,
+            account_repository=mock_account_repo,
+        )
+
         with pytest.raises(AccountNotFoundError):
             await command.execute(
                 transaction_id=txn.id,
-                category_account_id=fake_id,
+                counter_account_id=fake_id,
             )
 
     # =========================================================================
@@ -513,29 +618,43 @@ class TestEditTransactionCommand:
 
     async def test_multiple_operations_in_one_call(
         self,
-        command,
         mock_transaction_repo,
         mock_account_repo,
     ):
         """Can update description, counterparty, and entries in one call."""
         txn = mock_transaction_repo._transaction
-        asset = mock_account_repo._asset_account
-        expense = mock_account_repo._expense_account
+        tracker = DomainCallTracker()
 
-        entries = [
-            JournalEntryInput.debit_entry(expense.id, Decimal("100.00")),
-            JournalEntryInput.credit_entry(asset.id, Decimal("100.00")),
-        ]
+        def mock_replace_entries(transaction, entries, accounts):
+            tracker.replace_count += 1
 
-        await command.execute(
-            transaction_id=txn.id,
-            entries=entries,
-            description="New description",
-            counterparty="New counterparty",
-        )
+        with patch(
+            "swen.application.accounting.commands.edit_transaction_command.TransactionEditService.replace_entries",
+            staticmethod(mock_replace_entries),
+        ):
+            command = EditTransactionCommand(
+                transaction_repository=mock_transaction_repo,
+                account_repository=mock_account_repo,
+            )
+
+            entries = [
+                JournalEntryInput.debit_entry(
+                    mock_account_repo._expense_account.id, Decimal("100.00")
+                ),
+                JournalEntryInput.credit_entry(
+                    mock_account_repo._asset_account.id, Decimal("100.00")
+                ),
+            ]
+
+            await command.execute(
+                transaction_id=txn.id,
+                entries=entries,
+                description="New description",
+                counterparty="New counterparty",
+            )
 
         # All operations should have been called
-        txn.clear_entries.assert_called_once()
         txn.update_description.assert_called_once_with("New description")
         txn.update_counterparty.assert_called_once_with("New counterparty")
+        assert tracker.replace_count == 1
         mock_transaction_repo.save.assert_called_once()

--- a/services/backend/tests/swen/unit/domain/accounting/test_transaction_edit_service.py
+++ b/services/backend/tests/swen/unit/domain/accounting/test_transaction_edit_service.py
@@ -1,0 +1,356 @@
+"""Unit tests for TransactionEditService domain service."""
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from swen.domain.accounting.entities.account_type import AccountType
+from swen.domain.accounting.services import TransactionEditService
+from swen.domain.accounting.value_objects import Currency, JournalEntryInput, Money
+from swen.domain.shared.exceptions import BusinessRuleViolation, ValidationError
+
+
+@pytest.fixture
+def mock_account():
+    """Create a mock account."""
+
+    def _create(
+        account_type: AccountType = AccountType.ASSET,
+        name: str | None = None,
+        currency: Currency = Currency("EUR"),
+    ):
+        account = MagicMock()
+        account.id = uuid4()
+        account.name = name or f"Test {account_type.value}"
+        account.account_type = account_type
+        account.default_currency = currency
+        account.is_active = True
+        return account
+
+    return _create
+
+
+@pytest.fixture
+def mock_transaction():
+    """Create a mock transaction."""
+
+    def _create(
+        is_bank_import: bool = False,
+        is_posted: bool = False,
+        entries: list | None = None,
+        protected_count: int = 0,
+    ):
+        txn = MagicMock()
+        txn.is_posted = is_posted
+        txn.is_bank_import = is_bank_import
+        txn.entries = entries or []
+        txn.protected_entries = [MagicMock() for _ in range(protected_count)]
+
+        # Track calls
+        txn.added_debits = []
+        txn.added_credits = []
+
+        def mock_add_debit(account, money):
+            txn.added_debits.append((account, money))
+
+        def mock_add_credit(account, money):
+            txn.added_credits.append((account, money))
+
+        txn.add_debit = MagicMock(side_effect=mock_add_debit)
+        txn.add_credit = MagicMock(side_effect=mock_add_credit)
+        txn.clear_entries = MagicMock()
+        txn.update_description = MagicMock()
+        txn.update_counterparty = MagicMock()
+        txn.set_metadata_raw = MagicMock()
+
+        return txn
+
+    return _create
+
+
+class TestTransactionEditServiceReplaceEntries:
+    """Tests for TransactionEditService.replace_entries."""
+
+    def test_replace_entries_basic(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """Basic entry replacement works."""
+        expense = mock_account(AccountType.EXPENSE, "Groceries")
+        asset = mock_account(AccountType.ASSET, "Checking")
+
+        accounts = {expense.id: expense, asset.id: asset}
+        entries = [
+            JournalEntryInput.debit_entry(expense.id, Decimal("50.00")),
+            JournalEntryInput.credit_entry(asset.id, Decimal("50.00")),
+        ]
+
+        txn = mock_transaction()
+        TransactionEditService.replace_entries(txn, entries, accounts)
+
+        txn.clear_entries.assert_called_once()
+        assert txn.add_debit.call_count == 1
+        assert txn.add_credit.call_count == 1
+
+    def test_replace_entries_requires_minimum_two(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """At least 2 entries required."""
+        expense = mock_account(AccountType.EXPENSE, "Groceries")
+        asset = mock_account(AccountType.ASSET, "Checking")
+
+        accounts = {expense.id: expense, asset.id: asset}
+        entries = [
+            JournalEntryInput.debit_entry(expense.id, Decimal("50.00")),
+        ]
+
+        txn = mock_transaction()
+        with pytest.raises(ValidationError, match="at least 2"):
+            TransactionEditService.replace_entries(txn, entries, accounts)
+
+        txn.clear_entries.assert_called_once()
+
+    def test_replace_entries_with_protected_entries_passes_minimum(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """With 1 protected entry, only 1 new entry required."""
+        expense = mock_account(AccountType.EXPENSE, "Groceries")
+
+        accounts = {expense.id: expense}
+        entries = [
+            JournalEntryInput.debit_entry(expense.id, Decimal("50.00")),
+        ]
+
+        txn = mock_transaction(protected_count=1)
+        TransactionEditService.replace_entries(txn, entries, accounts)
+
+        # 1 protected + 1 new = 2, passes minimum
+        assert txn.add_debit.call_count == 1
+
+    def test_replace_entries_with_protected_entries_fails_minimum(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """With 1 protected entry, 0 new entries fails minimum."""
+        accounts = {}
+        entries = []
+
+        txn = mock_transaction(protected_count=1)
+        with pytest.raises(ValidationError, match="at least 2"):
+            TransactionEditService.replace_entries(txn, entries, accounts)
+
+    def test_replace_entries_account_not_found(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """Raises KeyError for unknown account (dict lookup)."""
+        expense = mock_account(AccountType.EXPENSE, "Groceries")
+        asset = mock_account(AccountType.ASSET, "Checking")
+
+        accounts = {expense.id: expense}
+        entries = [
+            JournalEntryInput.debit_entry(expense.id, Decimal("50.00")),
+            JournalEntryInput.credit_entry(uuid4(), Decimal("50.00")),
+        ]
+
+        txn = mock_transaction()
+        with pytest.raises(KeyError):
+            TransactionEditService.replace_entries(txn, entries, accounts)
+
+    def test_replace_entries_multi_entry(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """Multi-entry replacement works."""
+        expense1 = mock_account(AccountType.EXPENSE, "Groceries")
+        expense2 = mock_account(AccountType.EXPENSE, "Restaurant")
+        asset = mock_account(AccountType.ASSET, "Checking")
+
+        accounts = {expense1.id: expense1, expense2.id: expense2, asset.id: asset}
+        entries = [
+            JournalEntryInput.debit_entry(expense1.id, Decimal("30.00")),
+            JournalEntryInput.debit_entry(expense2.id, Decimal("20.00")),
+            JournalEntryInput.credit_entry(asset.id, Decimal("50.00")),
+        ]
+
+        txn = mock_transaction()
+        TransactionEditService.replace_entries(txn, entries, accounts)
+
+        assert txn.add_debit.call_count == 2
+        assert txn.add_credit.call_count == 1
+
+
+class TestTransactionEditServiceChangeCounterAccount:
+    """Tests for TransactionEditService.change_counter_account."""
+
+    def test_change_counter_account_basic(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """Basic category change works."""
+        old_expense = mock_account(AccountType.EXPENSE, "Groceries")
+        new_expense = mock_account(AccountType.EXPENSE, "Restaurant")
+        asset = mock_account(AccountType.ASSET, "Checking")
+
+        # Create mock entries
+        category_entry = MagicMock()
+        category_entry.account = old_expense
+        category_entry.is_debit.return_value = True
+        category_entry.debit = Money(Decimal("50.00"), Currency("EUR"))
+        category_entry.credit = Money(Decimal("0"), Currency("EUR"))
+
+        payment_entry = MagicMock()
+        payment_entry.account = asset
+        payment_entry.is_debit.return_value = False
+
+        txn = mock_transaction(entries=[category_entry, payment_entry])
+
+        TransactionEditService.change_counter_account(txn, new_expense)
+
+        txn.clear_entries.assert_called_once()
+        # Should add new entries
+        assert txn.add_debit.call_count >= 1 or txn.add_credit.call_count >= 1
+
+    def test_change_counter_account_with_liability(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """Category change works with liability (credit card) as payment account."""
+        old_expense = mock_account(AccountType.EXPENSE, "Groceries")
+        new_expense = mock_account(AccountType.EXPENSE, "Restaurant")
+        liability = mock_account(AccountType.LIABILITY, "Credit Card")
+
+        category_entry = MagicMock()
+        category_entry.account = old_expense
+        category_entry.is_debit.return_value = True
+        category_entry.debit = Money(Decimal("50.00"), Currency("EUR"))
+        category_entry.credit = Money(Decimal("0"), Currency("EUR"))
+
+        payment_entry = MagicMock()
+        payment_entry.account = liability
+        payment_entry.is_debit.return_value = False
+
+        txn = mock_transaction(entries=[category_entry, payment_entry])
+
+        TransactionEditService.change_counter_account(txn, new_expense)
+
+        txn.clear_entries.assert_called_once()
+
+    def test_change_counter_account_missing_category_entry(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """Raises BusinessRuleViolation when no category entry found."""
+        asset = mock_account(AccountType.ASSET, "Checking")
+
+        # Only payment entries, no category
+        payment_entry = MagicMock()
+        payment_entry.account = asset
+        payment_entry.is_debit.return_value = False
+
+        txn = mock_transaction(entries=[payment_entry])
+
+        income = mock_account(AccountType.ASSET, "Savings")
+        with pytest.raises(BusinessRuleViolation, match="category"):
+            TransactionEditService.change_counter_account(txn, income)
+
+    def test_change_counter_account_missing_payment_entry(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """Raises BusinessRuleViolation when no payment entry found."""
+        expense = mock_account(AccountType.EXPENSE, "Groceries")
+
+        # Only category entry, no payment
+        category_entry = MagicMock()
+        category_entry.account = expense
+        category_entry.is_debit.return_value = True
+        category_entry.debit = Money(Decimal("50.00"), Currency("EUR"))
+        category_entry.credit = Money(Decimal("0"), Currency("EUR"))
+
+        txn = mock_transaction(entries=[category_entry])
+
+        new_expense = mock_account(AccountType.EXPENSE, "Restaurant")
+        with pytest.raises(BusinessRuleViolation, match="category"):
+            TransactionEditService.change_counter_account(txn, new_expense)
+
+    def test_change_counter_account_invalid_new_category_type(
+        self,
+        mock_transaction,
+        mock_account,
+    ):
+        """Raises InvalidAccountTypeError when new category is not expense/income."""
+        old_expense = mock_account(AccountType.EXPENSE, "Groceries")
+        asset = mock_account(AccountType.ASSET, "Checking")
+
+        category_entry = MagicMock()
+        category_entry.account = old_expense
+        category_entry.is_debit.return_value = True
+        category_entry.debit = Money(Decimal("50.00"), Currency("EUR"))
+        category_entry.credit = Money(Decimal("0"), Currency("EUR"))
+
+        payment_entry = MagicMock()
+        payment_entry.account = asset
+
+        txn = mock_transaction(entries=[category_entry, payment_entry])
+
+        # Asset account is not a valid category
+        invalid_category = mock_account(AccountType.ASSET, "Savings")
+        with pytest.raises(Exception, match="asset"):
+            TransactionEditService.change_counter_account(txn, invalid_category)
+
+
+class TestTransactionEditServiceUpdateMetadata:
+    """Tests for TransactionEditService.update_metadata."""
+
+    def test_update_metadata_basic(
+        self,
+        mock_transaction,
+    ):
+        """Basic metadata update works."""
+        txn = mock_transaction()
+        TransactionEditService.update_metadata(txn, {"custom_key": "value123"})
+
+        txn.set_metadata_raw.assert_called_once_with("custom_key", "value123")
+
+    def test_update_metadata_rejects_reserved_keys(
+        self,
+        mock_transaction,
+    ):
+        """Reserved metadata keys are rejected."""
+        txn = mock_transaction()
+        with pytest.raises(ValidationError, match="reserved"):
+            TransactionEditService.update_metadata(txn, {"source": "hacked"})
+
+        txn.set_metadata_raw.assert_not_called()
+
+    def test_update_metadata_allows_non_reserved_keys(
+        self,
+        mock_transaction,
+    ):
+        """Non-reserved keys are allowed."""
+        txn = mock_transaction()
+        TransactionEditService.update_metadata(
+            txn,
+            {
+                "custom_tag": "value",
+                "merchant": "TEST",
+                "is_recurring": False,
+            },
+        )
+
+        assert txn.set_metadata_raw.call_count == 3


### PR DESCRIPTION
## Description

The `EditTransactionCommand` had a quite big chunk of business rules. We have to externalize this to a stateless domain service.  

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [ ] `[Feat]` - New feature
- [ ] `[Fix]` - Bug fix
- [x] `[Refactor]` - Code refactoring (no functional change)
- [ ] `[Docs]` - Documentation update
- [ ] `[Test]` - Test additions or updates
- [ ] `[Chore]` - Maintenance (dependencies, CI, configs)

## Checklist

- [x] PR title follows the format: `[Type] Short description`
- [x] Code follows project conventions
- [x] Tests added/updated where applicable
- [x] Documentation updated if needed

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
