### PR TITLE
[Refactor] ML service renamings for better readability

### DIFF
--- a/services/backend/src/swen/application/accounting/commands/create_account_command.py
+++ b/services/backend/src/swen/application/accounting/commands/create_account_command.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from swen_ml_contracts import AccountOption
-
 from swen.application.accounting.dtos.chart_of_accounts_dto import CreateAccountDTO
+from swen.application.ports.account_classifier_training import AccountForClassification
 from swen.application.ports.unit_of_work import UnitOfWork
 from swen.domain.accounting.entities import Account, AccountType
 from swen.domain.accounting.exceptions import (
@@ -23,8 +22,10 @@ from swen.domain.accounting.value_objects.currency import SUPPORTED_CURRENCIES
 
 if TYPE_CHECKING:
     from swen.application.factories import RepositoryFactory
+    from swen.application.ports.account_classifier_training import (
+        AccountClassifierTrainingPort,
+    )
     from swen.domain.shared.current_user import CurrentUser
-    from swen.infrastructure.integration.ml.client import MLServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -38,26 +39,26 @@ class CreateAccountCommand:
         account_hierarchy_service: AccountHierarchyService,
         current_user: CurrentUser,
         uow: UnitOfWork,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ):
         self._account_repo = account_repository
         self._account_hierarchy_service = account_hierarchy_service
         self._user_id = current_user.user_id
         self._uow = uow
-        self._ml_client = ml_client
+        self._ml_port = ml_port
 
     @classmethod
     def from_factory(
         cls,
         factory: RepositoryFactory,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ) -> CreateAccountCommand:
         return cls(
             account_repository=factory.account_repository(),
             account_hierarchy_service=AccountHierarchyService.from_factory(factory),
             current_user=factory.current_user,
             uow=factory.unit_of_work(),
-            ml_client=ml_client,
+            ml_port=ml_port,
         )
 
     async def execute(self, dto: CreateAccountDTO) -> Account:
@@ -133,16 +134,16 @@ class CreateAccountCommand:
 
     def _trigger_account_embedding(self, account: Account) -> None:
         """Trigger ML service to embed this account's anchor for classification."""
-        if not self._ml_client:
+        if not self._ml_port:
             return
 
         accounts = [
-            AccountOption(
+            AccountForClassification(
                 account_id=account.id,
                 account_number=account.account_number,
                 name=account.name,
-                account_type=account.account_type.value.lower(),  # type: ignore[arg-type]
+                account_type=account.account_type.value.lower(),
                 description=account.description,
             )
         ]
-        self._ml_client.embed_accounts_fire_and_forget(self._user_id, accounts)
+        self._ml_port.embed_accounts_fire_and_forget(self._user_id, accounts)

--- a/services/backend/src/swen/application/accounting/commands/generate_default_accounts_command.py
+++ b/services/backend/src/swen/application/accounting/commands/generate_default_accounts_command.py
@@ -6,8 +6,7 @@ import logging
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from swen_ml_contracts import AccountOption
-
+from swen.application.ports.account_classifier_training import AccountForClassification
 from swen.application.ports.unit_of_work import UnitOfWork
 from swen.domain.accounting.entities import Account, AccountType
 from swen.domain.accounting.repositories import AccountRepository
@@ -15,8 +14,10 @@ from swen.domain.accounting.value_objects import Currency
 
 if TYPE_CHECKING:
     from swen.application.factories import RepositoryFactory
+    from swen.application.ports.account_classifier_training import (
+        AccountClassifierTrainingPort,
+    )
     from swen.domain.shared.current_user import CurrentUser
-    from swen.infrastructure.integration.ml.client import MLServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -39,24 +40,24 @@ class GenerateDefaultAccountsCommand:
         account_repository: AccountRepository,
         current_user: CurrentUser,
         uow: UnitOfWork,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ):
         self._account_repo = account_repository
         self._user_id = current_user.user_id
         self._uow = uow
-        self._ml_client = ml_client
+        self._ml_port = ml_port
 
     @classmethod
     def from_factory(
         cls,
         factory: RepositoryFactory,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ) -> GenerateDefaultAccountsCommand:
         return cls(
             account_repository=factory.account_repository(),
             current_user=factory.current_user,
             uow=factory.unit_of_work(),
-            ml_client=ml_client,
+            ml_port=ml_port,
         )
 
     async def execute(
@@ -95,15 +96,15 @@ class GenerateDefaultAccountsCommand:
 
     def _trigger_account_embeddings(self, accounts: list[Account]) -> None:
         """Trigger ML service to embed account anchors for classification."""
-        if not self._ml_client:
+        if not self._ml_port:
             return
 
         classification_accounts = [
-            AccountOption(
+            AccountForClassification(
                 account_id=account.id,
                 account_number=account.account_number,
                 name=account.name,
-                account_type=account.account_type.value.lower(),  # type: ignore[arg-type]
+                account_type=account.account_type.value.lower(),
                 description=account.description,
             )
             for account in accounts
@@ -111,7 +112,7 @@ class GenerateDefaultAccountsCommand:
         ]
 
         if classification_accounts:
-            self._ml_client.embed_accounts_fire_and_forget(
+            self._ml_port.embed_accounts_fire_and_forget(
                 self._user_id, classification_accounts
             )
 

--- a/services/backend/src/swen/application/accounting/commands/post_transaction_command.py
+++ b/services/backend/src/swen/application/accounting/commands/post_transaction_command.py
@@ -19,7 +19,9 @@ from swen.domain.shared.exceptions import ValidationError
 
 if TYPE_CHECKING:
     from swen.application.factories import RepositoryFactory
-    from swen.application.ports.ml_service import MLServicePort
+    from swen.application.ports.account_classifier_training import (
+        AccountClassifierTrainingPort,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +33,7 @@ class PostTransactionCommand:
         self,
         transaction_repository: TransactionRepository,
         uow: UnitOfWork,
-        ml_port: MLServicePort | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ):
         self._transaction_repo = transaction_repository
         self._uow = uow
@@ -41,7 +43,7 @@ class PostTransactionCommand:
     def from_factory(
         cls,
         factory: RepositoryFactory,
-        ml_port: MLServicePort | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ) -> PostTransactionCommand:
         return cls(
             transaction_repository=factory.transaction_repository(),
@@ -103,7 +105,7 @@ class BulkPostTransactionsCommand:
         self,
         transaction_repository: TransactionRepository,
         uow: UnitOfWork,
-        ml_port: MLServicePort | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ):
         self._transaction_repo = transaction_repository
         self._uow = uow
@@ -113,7 +115,7 @@ class BulkPostTransactionsCommand:
     def from_factory(
         cls,
         factory: RepositoryFactory,
-        ml_port: MLServicePort | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ) -> BulkPostTransactionsCommand:
         return cls(
             transaction_repository=factory.transaction_repository(),

--- a/services/backend/src/swen/application/accounting/commands/update_account_command.py
+++ b/services/backend/src/swen/application/accounting/commands/update_account_command.py
@@ -6,12 +6,11 @@ import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from swen_ml_contracts import AccountOption
-
 from swen.application.accounting.dtos.chart_of_accounts_dto import (
     ParentAction,
     UpdateAccountDTO,
 )
+from swen.application.ports.account_classifier_training import AccountForClassification
 from swen.application.ports.unit_of_work import UnitOfWork
 from swen.domain.accounting.entities import Account
 from swen.domain.accounting.exceptions import (
@@ -24,8 +23,10 @@ from swen.domain.accounting.services import AccountHierarchyService
 
 if TYPE_CHECKING:
     from swen.application.factories import RepositoryFactory
+    from swen.application.ports.account_classifier_training import (
+        AccountClassifierTrainingPort,
+    )
     from swen.domain.shared.current_user import CurrentUser
-    from swen.infrastructure.integration.ml.client import MLServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -39,26 +40,26 @@ class UpdateAccountCommand:
         account_hierarchy_service: AccountHierarchyService,
         current_user: CurrentUser,
         uow: UnitOfWork,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ):
         self._account_repo = account_repository
         self._account_hierarchy_service = account_hierarchy_service
         self._user_id = current_user.user_id
         self._uow = uow
-        self._ml_client = ml_client
+        self._ml_port = ml_port
 
     @classmethod
     def from_factory(
         cls,
         factory: RepositoryFactory,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ) -> UpdateAccountCommand:
         return cls(
             account_repository=factory.account_repository(),
             account_hierarchy_service=AccountHierarchyService.from_factory(factory),
             current_user=factory.current_user,
             uow=factory.unit_of_work(),
-            ml_client=ml_client,
+            ml_port=ml_port,
         )
 
     async def execute(self, dto: UpdateAccountDTO) -> Account:
@@ -87,19 +88,19 @@ class UpdateAccountCommand:
 
     def _trigger_account_embedding(self, account: Account) -> None:
         """Trigger ML service to re-embed this account's anchor for classification."""
-        if not self._ml_client:
+        if not self._ml_port:
             return
 
         accounts = [
-            AccountOption(
+            AccountForClassification(
                 account_id=account.id,
                 account_number=account.account_number,
                 name=account.name,
-                account_type=account.account_type.value.lower(),  # type: ignore[arg-type]
+                account_type=account.account_type.value.lower(),
                 description=account.description,
             )
         ]
-        self._ml_client.embed_accounts_fire_and_forget(self._user_id, accounts)
+        self._ml_port.embed_accounts_fire_and_forget(self._user_id, accounts)
 
     async def _get_account(self, account_id: UUID) -> Account:
         account = await self._account_repo.find_by_id(account_id)
@@ -168,26 +169,26 @@ class DeactivateAccountCommand:
         account_hierarchy_service: AccountHierarchyService,
         current_user: CurrentUser,
         uow: UnitOfWork,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ):
         self._account_repo = account_repository
         self._account_hierarchy_service = account_hierarchy_service
         self._user_id = current_user.user_id
         self._uow = uow
-        self._ml_client = ml_client
+        self._ml_port = ml_port
 
     @classmethod
     def from_factory(
         cls,
         factory: RepositoryFactory,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ) -> DeactivateAccountCommand:
         return cls(
             account_repository=factory.account_repository(),
             account_hierarchy_service=AccountHierarchyService.from_factory(factory),
             current_user=factory.current_user,
             uow=factory.unit_of_work(),
-            ml_client=ml_client,
+            ml_port=ml_port,
         )
 
     async def execute(self, account_id: UUID) -> Account:
@@ -209,8 +210,8 @@ class DeactivateAccountCommand:
 
     def _delete_account_anchor(self, account_id: UUID) -> None:
         """Delete ML anchor for this account."""
-        if self._ml_client:
-            self._ml_client.delete_account_anchor_fire_and_forget(
+        if self._ml_port:
+            self._ml_port.delete_account_anchor_fire_and_forget(
                 self._user_id, account_id
             )
 
@@ -223,24 +224,24 @@ class ReactivateAccountCommand:
         account_repository: AccountRepository,
         current_user: CurrentUser,
         uow: UnitOfWork,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ):
         self._account_repo = account_repository
         self._user_id = current_user.user_id
         self._uow = uow
-        self._ml_client = ml_client
+        self._ml_port = ml_port
 
     @classmethod
     def from_factory(
         cls,
         factory: RepositoryFactory,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ) -> ReactivateAccountCommand:
         return cls(
             account_repository=factory.account_repository(),
             current_user=factory.current_user,
             uow=factory.unit_of_work(),
-            ml_client=ml_client,
+            ml_port=ml_port,
         )
 
     async def execute(self, account_id: UUID) -> Account:
@@ -260,19 +261,19 @@ class ReactivateAccountCommand:
 
     def _trigger_account_embedding(self, account: Account) -> None:
         """Trigger ML service to embed this account's anchor for classification."""
-        if not self._ml_client:
+        if not self._ml_port:
             return
 
         accounts = [
-            AccountOption(
+            AccountForClassification(
                 account_id=account.id,
                 account_number=account.account_number,
                 name=account.name,
-                account_type=account.account_type.value.lower(),  # type: ignore[arg-type]
+                account_type=account.account_type.value.lower(),
                 description=account.description,
             )
         ]
-        self._ml_client.embed_accounts_fire_and_forget(self._user_id, accounts)
+        self._ml_port.embed_accounts_fire_and_forget(self._user_id, accounts)
 
 
 class DeleteAccountCommand:
@@ -284,26 +285,26 @@ class DeleteAccountCommand:
         account_hierarchy_service: AccountHierarchyService,
         current_user: CurrentUser,
         uow: UnitOfWork,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ):
         self._account_repo = account_repository
         self._account_hierarchy_service = account_hierarchy_service
         self._user_id = current_user.user_id
         self._uow = uow
-        self._ml_client = ml_client
+        self._ml_port = ml_port
 
     @classmethod
     def from_factory(
         cls,
         factory: RepositoryFactory,
-        ml_client: MLServiceClient | None = None,
+        ml_port: AccountClassifierTrainingPort | None = None,
     ) -> DeleteAccountCommand:
         return cls(
             account_repository=factory.account_repository(),
             account_hierarchy_service=AccountHierarchyService.from_factory(factory),
             current_user=factory.current_user,
             uow=factory.unit_of_work(),
-            ml_client=ml_client,
+            ml_port=ml_port,
         )
 
     async def execute(self, account_id: UUID) -> None:
@@ -328,7 +329,7 @@ class DeleteAccountCommand:
 
     def _delete_account_anchor(self, account_id: UUID) -> None:
         """Delete ML anchor for this account."""
-        if self._ml_client:
-            self._ml_client.delete_account_anchor_fire_and_forget(
+        if self._ml_port:
+            self._ml_port.delete_account_anchor_fire_and_forget(
                 self._user_id, account_id
             )

--- a/services/backend/src/swen/application/integration/services/ml_example_service.py
+++ b/services/backend/src/swen/application/integration/services/ml_example_service.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import logging
 from decimal import Decimal
 
-from swen.application.ports.ml_service import MLServicePort, TransactionExample
+from swen.application.ports.account_classifier_training import (
+    AccountClassifierTrainingPort,
+    TransactionExample,
+)
 from swen.domain.accounting import WellKnownAccounts
 from swen.domain.accounting.aggregates import Transaction
 from swen.domain.accounting.entities import AccountType
@@ -16,7 +19,7 @@ logger = logging.getLogger(__name__)
 class MLExampleService:
     """Extracts transaction examples for ML training."""
 
-    def __init__(self, ml_port: MLServicePort | None):
+    def __init__(self, ml_port: AccountClassifierTrainingPort | None):
         self._ml_port = ml_port
 
     def submit_example(self, transaction: Transaction) -> None:

--- a/services/backend/src/swen/application/ports/__init__.py
+++ b/services/backend/src/swen/application/ports/__init__.py
@@ -1,17 +1,17 @@
 """Application layer ports (aka interfaces)."""
 
-from swen.application.ports.analytics import AnalyticsReadPort
-from swen.application.ports.ml_service import (
-    MLServicePort,
+from swen.application.ports.account_classifier_training import (
+    AccountClassifierTrainingPort,
     TransactionExample,
 )
+from swen.application.ports.analytics import AnalyticsReadPort
 from swen.application.ports.system import DatabaseIntegrityPort
 from swen.application.ports.unit_of_work import UnitOfWork
 
 __all__ = [
+    "AccountClassifierTrainingPort",
     "AnalyticsReadPort",
     "DatabaseIntegrityPort",
-    "MLServicePort",
     "TransactionExample",
     "UnitOfWork",
 ]

--- a/services/backend/src/swen/application/ports/account_classifier_training.py
+++ b/services/backend/src/swen/application/ports/account_classifier_training.py
@@ -1,10 +1,11 @@
-"""ML Service port for application layer.
+"""Account classifier training port for application layer.
 
-This abstracts the ML service operations for training examples and
-account embeddings, allowing the application layer to remain independent
-of infrastructure details like HTTP clients and external API contracts.
+This abstracts feeding the counter-account classifier its training data:
+labeled transaction examples and per-account anchor embeddings. It keeps
+the application layer independent of infrastructure details like HTTP
+clients and external API contracts.
 
-Classification is handled separately via the domain-level
+Classification itself is handled separately via the domain-level
 CounterAccountProposalPort.
 """
 
@@ -40,12 +41,12 @@ class AccountForClassification:
     description: str | None = None
 
 
-class MLServicePort(ABC):
-    """Port interface for ML service operations (training + embeddings).
+class AccountClassifierTrainingPort(ABC):
+    """Port for supplying the counter-account classifier its training data.
 
     Classification is handled by ``CounterAccountProposalPort`` in the
-    integration domain — this port covers only example submission and
-    account embedding.
+    integration domain. This port covers example submission and account
+    anchor embedding/deletion.
     """
 
     @property
@@ -67,4 +68,23 @@ class MLServicePort(ABC):
 
         Called when accounts are created or updated.
         Returns True if successful.
+        """
+
+    @abstractmethod
+    def embed_accounts_fire_and_forget(
+        self,
+        user_id: UUID,
+        accounts: list[AccountForClassification],
+    ) -> None:
+        """Compute and store anchor embeddings for accounts (fire-and-forget)."""
+
+    @abstractmethod
+    def delete_account_anchor_fire_and_forget(
+        self,
+        user_id: UUID,
+        account_id: UUID,
+    ) -> None:
+        """Delete the anchor embedding for an account (fire-and-forget).
+
+        Called when an account is deactivated or deleted.
         """

--- a/services/backend/src/swen/application/ports/account_classifier_training.py
+++ b/services/backend/src/swen/application/ports/account_classifier_training.py
@@ -5,19 +5,21 @@ labeled transaction examples and per-account anchor embeddings. It keeps
 the application layer independent of infrastructure details like HTTP
 clients and external API contracts.
 
-Classification itself is handled separately via the domain-level
+Transaction Classification itself is handled separately via the domain-level
 CounterAccountProposalPort.
 """
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from decimal import Decimal
 from uuid import UUID
 
+from pydantic import BaseModel, ConfigDict
 
-@dataclass(frozen=True)
-class TransactionExample:
-    """Domain representation of a transaction example for ML training."""
+
+class TransactionExample(BaseModel):
+    """Transaction example for ML training."""
+
+    model_config = ConfigDict(frozen=True)
 
     user_id: UUID
     account_id: UUID
@@ -30,9 +32,10 @@ class TransactionExample:
     counterparty_iban: str | None = None
 
 
-@dataclass(frozen=True)
-class AccountForClassification:
-    """Domain representation of an account option for embedding."""
+class AccountForClassification(BaseModel):
+    """Account represnetaiton for embedding."""
+
+    model_config = ConfigDict(frozen=True)
 
     account_id: UUID
     account_number: str
@@ -44,7 +47,7 @@ class AccountForClassification:
 class AccountClassifierTrainingPort(ABC):
     """Port for supplying the counter-account classifier its training data.
 
-    Classification is handled by ``CounterAccountProposalPort`` in the
+    Transaction Classification is handled by ``CounterAccountProposalPort`` in the
     integration domain. This port covers example submission and account
     anchor embedding/deletion.
     """

--- a/services/backend/src/swen/domain/banking/value_objects/bank_account.py
+++ b/services/backend/src/swen/domain/banking/value_objects/bank_account.py
@@ -71,7 +71,7 @@ class BankAccount(BaseModel):
     )
 
     model_config = ConfigDict(
-        frozen=True,  # Immutable like dataclass(frozen=True)
+        frozen=True,
         str_strip_whitespace=True,
         validate_assignment=True,
     )

--- a/services/backend/src/swen/infrastructure/integration/__init__.py
+++ b/services/backend/src/swen/infrastructure/integration/__init__.py
@@ -1,11 +1,11 @@
 """Integration adapters for external services."""
 
 from swen.infrastructure.integration.ml import (
-    MLServiceAdapter,
+    MLAccountClassifierTrainingAdapter,
     MLServiceClient,
 )
 
 __all__ = [
-    "MLServiceAdapter",
+    "MLAccountClassifierTrainingAdapter",
     "MLServiceClient",
 ]

--- a/services/backend/src/swen/infrastructure/integration/ml/__init__.py
+++ b/services/backend/src/swen/infrastructure/integration/ml/__init__.py
@@ -1,9 +1,11 @@
 """ML service integration for transaction classification."""
 
-from swen.infrastructure.integration.ml.adapter import MLServiceAdapter
 from swen.infrastructure.integration.ml.client import MLServiceClient
+from swen.infrastructure.integration.ml.training_adapter import (
+    MLAccountClassifierTrainingAdapter,
+)
 
 __all__ = [
-    "MLServiceAdapter",
+    "MLAccountClassifierTrainingAdapter",
     "MLServiceClient",
 ]

--- a/services/backend/src/swen/infrastructure/integration/ml/training_adapter.py
+++ b/services/backend/src/swen/infrastructure/integration/ml/training_adapter.py
@@ -71,16 +71,7 @@ class MLAccountClassifierTrainingAdapter(AccountClassifierTrainingPort):
         if not self._client.enabled:
             return False
 
-        ml_accounts = [
-            AccountOption(
-                account_id=acc.account_id,
-                account_number=acc.account_number,
-                name=acc.name,
-                account_type=acc.account_type,
-                description=acc.description,
-            )
-            for acc in accounts
-        ]
+        ml_accounts = [AccountOption.model_validate(acc) for acc in accounts]
 
         result = await self._client.embed_accounts(user_id, ml_accounts)
         return result is not None and result.embedded > 0
@@ -94,16 +85,7 @@ class MLAccountClassifierTrainingAdapter(AccountClassifierTrainingPort):
         if not self._client.enabled:
             return
 
-        ml_accounts = [
-            AccountOption(
-                account_id=acc.account_id,
-                account_number=acc.account_number,
-                name=acc.name,
-                account_type=acc.account_type,
-                description=acc.description,
-            )
-            for acc in accounts
-        ]
+        ml_accounts = [AccountOption.model_validate(acc) for acc in accounts]
 
         self._client.embed_accounts_fire_and_forget(user_id, ml_accounts)
 

--- a/services/backend/src/swen/infrastructure/integration/ml/training_adapter.py
+++ b/services/backend/src/swen/infrastructure/integration/ml/training_adapter.py
@@ -1,4 +1,4 @@
-"""ML Service adapter implementing the application port.
+"""ML-backed implementation of AccountClassifierTrainingPort.
 
 Handles example submission and account embeddings. Classification is
 handled separately by ``MLCounterAccountAdapter``.
@@ -11,9 +11,9 @@ from typing import TYPE_CHECKING
 
 from swen_ml_contracts import AccountOption, StoreExampleRequest
 
-from swen.application.ports.ml_service import (
+from swen.application.ports.account_classifier_training import (
+    AccountClassifierTrainingPort,
     AccountForClassification,
-    MLServicePort,
     TransactionExample,
 )
 
@@ -25,8 +25,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class MLServiceAdapter(MLServicePort):
-    """Infrastructure adapter that implements MLServicePort.
+class MLAccountClassifierTrainingAdapter(AccountClassifierTrainingPort):
+    """Infrastructure adapter that implements AccountClassifierTrainingPort.
 
     Translates domain objects to ML contracts and delegates to the HTTP client.
     Covers example submission and account embeddings only.
@@ -84,3 +84,36 @@ class MLServiceAdapter(MLServicePort):
 
         result = await self._client.embed_accounts(user_id, ml_accounts)
         return result is not None and result.embedded > 0
+
+    def embed_accounts_fire_and_forget(
+        self,
+        user_id: UUID,
+        accounts: list[AccountForClassification],
+    ) -> None:
+        """Compute and store anchor embeddings for accounts (fire-and-forget)."""
+        if not self._client.enabled:
+            return
+
+        ml_accounts = [
+            AccountOption(
+                account_id=acc.account_id,
+                account_number=acc.account_number,
+                name=acc.name,
+                account_type=acc.account_type,
+                description=acc.description,
+            )
+            for acc in accounts
+        ]
+
+        self._client.embed_accounts_fire_and_forget(user_id, ml_accounts)
+
+    def delete_account_anchor_fire_and_forget(
+        self,
+        user_id: UUID,
+        account_id: UUID,
+    ) -> None:
+        """Delete the anchor embedding for an account (fire-and-forget)."""
+        if not self._client.enabled:
+            return
+
+        self._client.delete_account_anchor_fire_and_forget(user_id, account_id)

--- a/services/backend/src/swen/presentation/api/accounting/routers/accounts.py
+++ b/services/backend/src/swen/presentation/api/accounting/routers/accounts.py
@@ -27,7 +27,7 @@ from swen.presentation.api.accounting.schemas.accounts import (
     AccountSummaryResponse,
     AccountUpdateRequest,
 )
-from swen.presentation.api.dependencies import MLClient, RepoFactory
+from swen.presentation.api.dependencies import ClassifierTrainingPortDep, RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ def _to_account_response(dto: AccountSummaryDTO) -> AccountSummaryResponse:
     },
 )
 async def list_accounts(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     account_type: AccountTypeFilter = None,
     active_only: ActiveOnlyFilter = True,
 ) -> AccountListResponse:
@@ -95,15 +95,15 @@ async def list_accounts(
 )
 async def create_account(
     request: AccountCreateRequest,
-    factory: RepoFactory,
-    ml_client: MLClient,
+    factory: RepoFactoryDep,
+    ml_port: ClassifierTrainingPortDep,
 ) -> AccountSummaryResponse:
     """
     Create a new account in the chart of accounts.
 
     Account types: asset, liability, equity, income, expense
     """
-    command = CreateAccountCommand.from_factory(factory, ml_client=ml_client)
+    command = CreateAccountCommand.from_factory(factory, ml_port=ml_port)
     account = await command.execute(CreateAccountDTO(**request.model_dump()))
 
     logger.info("Account created: %s (%s)", account.name, account.account_number)
@@ -122,7 +122,7 @@ async def create_account(
 )
 async def get_account(
     account_id: UUID,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> AccountSummaryResponse:
     """Get a specific account by ID."""
     query = ListAccountsQuery.from_factory(factory)
@@ -147,7 +147,7 @@ async def get_account(
 )
 async def get_account_stats(
     account_id: UUID,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     days: StatsPeriodDays = None,
     include_drafts: StatsIncludeDrafts = True,
 ) -> AccountStatsResponse:
@@ -192,8 +192,8 @@ async def get_account_stats(
 async def update_account(
     account_id: UUID,
     request: AccountUpdateRequest,
-    factory: RepoFactory,
-    ml_client: MLClient,
+    factory: RepoFactoryDep,
+    ml_port: ClassifierTrainingPortDep,
 ) -> AccountSummaryResponse:
     """Update an account (name, account_number, description, and/or parent).
 
@@ -202,7 +202,7 @@ async def update_account(
     - 'set': Set parent to parent_id (requires parent_id)
     - 'remove': Remove parent, make top-level
     """
-    command = UpdateAccountCommand.from_factory(factory, ml_client=ml_client)
+    command = UpdateAccountCommand.from_factory(factory, ml_port=ml_port)
     account = await command.execute(
         UpdateAccountDTO(account_id=account_id, **request.model_dump()),
     )
@@ -223,15 +223,15 @@ async def update_account(
 )
 async def deactivate_account(
     account_id: UUID,
-    factory: RepoFactory,
-    ml_client: MLClient,
+    factory: RepoFactoryDep,
+    ml_port: ClassifierTrainingPortDep,
 ) -> None:
     """
     Deactivate an account (soft delete).
 
     The account is marked as inactive but not removed from the database.
     """
-    command = DeactivateAccountCommand.from_factory(factory, ml_client=ml_client)
+    command = DeactivateAccountCommand.from_factory(factory, ml_port=ml_port)
     await command.execute(account_id=account_id)
 
     logger.info("Account deactivated: %s", account_id)
@@ -247,15 +247,15 @@ async def deactivate_account(
 )
 async def reactivate_account(
     account_id: UUID,
-    factory: RepoFactory,
-    ml_client: MLClient,
+    factory: RepoFactoryDep,
+    ml_port: ClassifierTrainingPortDep,
 ) -> AccountSummaryResponse:
     """
     Reactivate a previously deactivated account.
 
     The account will become visible in account lists and usable again.
     """
-    command = ReactivateAccountCommand.from_factory(factory, ml_client=ml_client)
+    command = ReactivateAccountCommand.from_factory(factory, ml_port=ml_port)
     account = await command.execute(account_id=account_id)
 
     logger.info("Account reactivated: %s", account_id)
@@ -277,8 +277,8 @@ async def reactivate_account(
 )
 async def delete_account(
     account_id: UUID,
-    factory: RepoFactory,
-    ml_client: MLClient,
+    factory: RepoFactoryDep,
+    ml_port: ClassifierTrainingPortDep,
 ) -> None:
     """
     Permanently delete an account.
@@ -287,7 +287,7 @@ async def delete_account(
     Only accounts with no transactions and no child accounts can be deleted.
     For accounts with data, use deactivate instead (soft delete).
     """
-    command = DeleteAccountCommand.from_factory(factory, ml_client=ml_client)
+    command = DeleteAccountCommand.from_factory(factory, ml_port=ml_port)
     await command.execute(account_id=account_id)
 
     logger.info("Account deleted permanently: %s", account_id)

--- a/services/backend/src/swen/presentation/api/accounting/routers/initialization.py
+++ b/services/backend/src/swen/presentation/api/accounting/routers/initialization.py
@@ -14,7 +14,7 @@ from swen.presentation.api.accounting.schemas.accounts import (
     InitChartResponse,
     InitEssentialsResponse,
 )
-from swen.presentation.api.dependencies import MLClient, RepoFactory
+from swen.presentation.api.dependencies import ClassifierTrainingPortDep, RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +31,8 @@ router = APIRouter()
     },
 )
 async def init_chart_of_accounts(
-    factory: RepoFactory,
-    ml_client: MLClient,
+    factory: RepoFactoryDep,
+    ml_port: ClassifierTrainingPortDep,
     request: InitChartRequest | None = None,
 ) -> InitChartResponse:
     """
@@ -62,7 +62,7 @@ async def init_chart_of_accounts(
     # Convert API enum to domain enum
     template = ChartTemplate(template_enum.value)
 
-    command = GenerateDefaultAccountsCommand.from_factory(factory, ml_client=ml_client)
+    command = GenerateDefaultAccountsCommand.from_factory(factory, ml_port=ml_port)
     result = await command.execute(template=template)
 
     if result.get("skipped"):
@@ -105,8 +105,8 @@ async def init_chart_of_accounts(
     },
 )
 async def init_essential_accounts(
-    factory: RepoFactory,
-    ml_client: MLClient,
+    factory: RepoFactoryDep,
+    ml_port: ClassifierTrainingPortDep,
 ) -> InitEssentialsResponse:
     """
     Initialize only the essential accounts required for basic operation.
@@ -120,7 +120,7 @@ async def init_essential_accounts(
     Use this when users choose manual account setup but you still need
     the essential accounts for cash transactions and fallback categorization.
     """
-    command = GenerateDefaultAccountsCommand.from_factory(factory, ml_client=ml_client)
+    command = GenerateDefaultAccountsCommand.from_factory(factory, ml_port=ml_port)
     result = await command.execute_essentials()
 
     if result["skipped"]:

--- a/services/backend/src/swen/presentation/api/accounting/routers/transactions.py
+++ b/services/backend/src/swen/presentation/api/accounting/routers/transactions.py
@@ -29,9 +29,6 @@ from swen.application.accounting.dtos import (
 from swen.application.accounting.queries import ListTransactionsQuery
 from swen.application.events.base import SyncProgressEvent
 from swen.domain.shared.exceptions import DomainException, ErrorCode
-from swen.infrastructure.integration.adapters.counter_account_resolution.ml import (
-    MLCounterAccountAdapter,
-)
 from swen.presentation.api.accounting.schemas.transactions import (
     BulkPostRequest,
     BulkPostResponse,
@@ -42,7 +39,11 @@ from swen.presentation.api.accounting.schemas.transactions import (
     TransactionResponse,
     TransactionUpdateRequest,
 )
-from swen.presentation.api.dependencies import MLClient, MLPort, RepoFactory
+from swen.presentation.api.dependencies import (
+    ClassifierTrainingPortDep,
+    CounterAccountPortDep,
+    RepoFactoryDep,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ _PAGE_SIZE = 50  # Transactions per page
     },
 )
 async def list_transactions(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     page: PageFilter = 1,
     status_filter: StatusFilter = None,
     account_number: AccountNumberFilter = None,
@@ -125,7 +126,7 @@ async def list_transactions(
 )
 async def create_transaction(
     request: TransactionCreateRequest,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> TransactionResponse:
     """
     Create a manual transaction with explicit journal entries.
@@ -202,7 +203,7 @@ async def create_transaction(
 )
 async def create_simple_transaction(
     request: SimpleTransactionToCreateRequest,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> TransactionResponse:
     """
     Create a transaction with automatic account resolution.
@@ -258,7 +259,7 @@ async def create_simple_transaction(
 )
 async def get_transaction(
     transaction_id: UUID,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> TransactionResponse:
     """Get detailed information about a specific transaction."""
     query = ListTransactionsQuery(
@@ -289,7 +290,7 @@ async def get_transaction(
 async def update_transaction(
     transaction_id: UUID,
     request: TransactionUpdateRequest,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> TransactionResponse:
     """
     Update an existing transaction.
@@ -325,8 +326,8 @@ async def update_transaction(
 )
 async def post_transaction(
     transaction_id: UUID,
-    factory: RepoFactory,
-    ml_port: MLPort,
+    factory: RepoFactoryDep,
+    ml_port: ClassifierTrainingPortDep,
 ) -> TransactionResponse:
     """
     Post a draft transaction.
@@ -351,7 +352,7 @@ async def post_transaction(
 )
 async def unpost_transaction(
     transaction_id: UUID,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> TransactionResponse:
     """
     Unpost a transaction (revert to draft).
@@ -377,7 +378,7 @@ async def unpost_transaction(
 )
 async def delete_transaction(
     transaction_id: UUID,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     force: ForceDeleteFilter = False,
 ) -> None:
     """
@@ -412,8 +413,8 @@ async def delete_transaction(
     },
 )
 async def reclassify_drafts_streaming(
-    factory: RepoFactory,
-    ml_client: MLClient,
+    factory: RepoFactoryDep,
+    resolution_port: CounterAccountPortDep,
     request: Optional[ReclassifyDraftsRequest] = None,
 ) -> StreamingResponse:
     """
@@ -454,9 +455,7 @@ async def reclassify_drafts_streaming(
 
     async def event_generator():
         try:
-            command = ReclassifyDraftsCommand.from_factory(
-                factory, MLCounterAccountAdapter(ml_client)
-            )
+            command = ReclassifyDraftsCommand.from_factory(factory, resolution_port)
         except Exception as e:
             logger.exception("Failed to create reclassify command: %s", e)
             yield _format_sse_event(
@@ -527,8 +526,8 @@ async def reclassify_drafts_streaming(
     },
 )
 async def bulk_post_transactions(
-    factory: RepoFactory,
-    ml_port: MLPort,
+    factory: RepoFactoryDep,
+    ml_port: ClassifierTrainingPortDep,
     request: BulkPostRequest,
 ) -> BulkPostResponse:
     """

--- a/services/backend/src/swen/presentation/api/admin/routers/admin.py
+++ b/services/backend/src/swen/presentation/api/admin/routers/admin.py
@@ -16,9 +16,9 @@ from swen.presentation.api.admin.schemas.admin import (
     UserSummaryResponse,
 )
 from swen.presentation.api.dependencies import (
-    AdminUser,
-    DBSession,
-    IdentityRepoFactory,
+    AdminUserDep,
+    DBSessionDep,
+    IdentityRepoFactoryDep,
     get_password_service,
 )
 from swen_identity import (
@@ -60,8 +60,8 @@ router.include_router(fints_provider_router)
     },
 )
 async def list_users(
-    _admin: AdminUser,  # Used for authorization check
-    session: DBSession,
+    _admin: AdminUserDep,  # Used for authorization check
+    session: DBSessionDep,
 ) -> list[UserSummaryResponse]:
     """List all users."""
     user_repo = UserRepositorySQLAlchemy(session)
@@ -90,8 +90,8 @@ async def list_users(
 )
 async def create_user(
     request: CreateUserRequest,
-    admin: AdminUser,
-    factory: IdentityRepoFactory,
+    admin: AdminUserDep,
+    factory: IdentityRepoFactoryDep,
     password_service: PasswordService,
 ) -> UserSummaryResponse:
     """Create a new user."""
@@ -139,8 +139,8 @@ async def create_user(
 )
 async def delete_user(
     user_id: UUID,
-    admin: AdminUser,
-    factory: IdentityRepoFactory,
+    admin: AdminUserDep,
+    factory: IdentityRepoFactoryDep,
 ) -> None:
     """Delete a user."""
     command = DeleteUserCommand.from_factory(factory)
@@ -174,8 +174,8 @@ async def delete_user(
 async def update_user_role(
     user_id: UUID,
     request: UpdateRoleRequest,
-    admin: AdminUser,
-    factory: IdentityRepoFactory,
+    admin: AdminUserDep,
+    factory: IdentityRepoFactoryDep,
 ) -> UserSummaryResponse:
     """Update a user's role."""
     try:

--- a/services/backend/src/swen/presentation/api/admin/routers/admin_fints_config.py
+++ b/services/backend/src/swen/presentation/api/admin/routers/admin_fints_config.py
@@ -16,8 +16,8 @@ from swen.presentation.api.admin.schemas.fints_config import (
     UpdateLocalFinTSConfigResponse,
 )
 from swen.presentation.api.dependencies import (
-    AdminUser,
-    RepoFactory,
+    AdminUserDep,
+    RepoFactoryDep,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,8 +35,8 @@ router = APIRouter(prefix="/local_fints_configuration", tags=["admin-local-fints
     },
 )
 async def get_local_fints_configuration(
-    _admin: AdminUser,
-    factory: RepoFactory,
+    _admin: AdminUserDep,
+    factory: RepoFactoryDep,
 ) -> FinTSConfigResponse:
     """Get current local FinTS configuration (admin only)."""
     query = GetFinTSConfigurationQuery.from_factory(factory)
@@ -62,8 +62,8 @@ async def get_local_fints_configuration(
     },
 )
 async def upsert_local_fints_configuration(
-    _admin: AdminUser,
-    factory: RepoFactory,
+    _admin: AdminUserDep,
+    factory: RepoFactoryDep,
     product_id: Annotated[str | None, Form(min_length=1, max_length=100)] = None,
     file: UploadFile | None = None,
 ) -> UpdateLocalFinTSConfigResponse:
@@ -109,8 +109,8 @@ async def upsert_local_fints_configuration(
     },
 )
 async def get_local_fints_configuration_status(
-    _admin: AdminUser,
-    factory: RepoFactory,
+    _admin: AdminUserDep,
+    factory: RepoFactoryDep,
 ) -> ConfigStatusResponse:
     """Check whether local FinTS is configured (admin only)."""
     query = GetFinTSConfigurationStatusQuery.from_factory(factory)

--- a/services/backend/src/swen/presentation/api/admin/routers/admin_fints_provider.py
+++ b/services/backend/src/swen/presentation/api/admin/routers/admin_fints_provider.py
@@ -22,8 +22,8 @@ from swen.presentation.api.admin.schemas.fints_provider import (
     SaveGeldstromApiConfigRequest,
 )
 from swen.presentation.api.dependencies import (
-    AdminUser,
-    RepoFactory,
+    AdminUserDep,
+    RepoFactoryDep,
 )
 
 logger = logging.getLogger(__name__)
@@ -40,8 +40,8 @@ router = APIRouter(prefix="/fints_provider", tags=["admin-fints-provider"])
     },
 )
 async def get_provider_status(
-    _admin: AdminUser,
-    factory: RepoFactory,
+    _admin: AdminUserDep,
+    factory: RepoFactoryDep,
 ) -> FintsProviderStatusResponse:
     """Get which FinTS provider is active and configured."""
     query = GetFintsProviderStatusQuery.from_factory(factory)
@@ -60,8 +60,8 @@ async def get_provider_status(
     },
 )
 async def get_geldstrom_api_config(
-    _admin: AdminUser,
-    factory: RepoFactory,
+    _admin: AdminUserDep,
+    factory: RepoFactoryDep,
 ) -> GeldstromApiConfigResponse:
     """Get Geldstrom API configuration with masked API key."""
     query = GetGeldstromApiConfigQuery.from_factory(factory)
@@ -87,8 +87,8 @@ async def get_geldstrom_api_config(
 )
 async def save_geldstrom_api_config(
     request: SaveGeldstromApiConfigRequest,
-    _admin: AdminUser,
-    factory: RepoFactory,
+    _admin: AdminUserDep,
+    factory: RepoFactoryDep,
 ) -> dict[str, str]:
     """Save Geldstrom API key and endpoint. Verifies endpoint health."""
     try:
@@ -117,8 +117,8 @@ async def save_geldstrom_api_config(
 )
 async def activate_provider(
     request: ActivateProviderRequest,
-    _admin: AdminUser,
-    factory: RepoFactory,
+    _admin: AdminUserDep,
+    factory: RepoFactoryDep,
 ) -> dict[str, str]:
     """Activate the specified FinTS provider, deactivating the other."""
     try:

--- a/services/backend/src/swen/presentation/api/analytics/routers/analytics.py
+++ b/services/backend/src/swen/presentation/api/analytics/routers/analytics.py
@@ -33,7 +33,7 @@ from swen.presentation.api.analytics.schemas.analytics import (
     TimeSeriesResponse,
     TopExpensesResponse,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ TopNParam = Annotated[
     },
 )
 async def get_spending_over_time(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     months: MonthsParam = 12,
     end_month: EndMonthParam = None,
     include_drafts: IncludeDraftsParam = False,
@@ -107,7 +107,7 @@ async def get_spending_over_time(
 )
 async def get_single_account_spending_over_time(
     account_id: UUID,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     months: MonthsParam = 12,
     end_month: EndMonthParam = None,
     include_drafts: IncludeDraftsParam = False,
@@ -144,7 +144,7 @@ async def get_single_account_spending_over_time(
     },
 )
 async def get_spending_breakdown(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     month: MonthParam = None,
     days: DaysParam = None,
     include_drafts: IncludeDraftsParam = False,
@@ -180,7 +180,7 @@ async def get_spending_breakdown(
     },
 )
 async def get_top_expenses(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     months: MonthsParam = 3,
     top_n: TopNParam = 10,
     end_month: EndMonthParam = None,
@@ -215,7 +215,7 @@ async def get_top_expenses(
     },
 )
 async def get_income_over_time(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     months: MonthsParam = 12,
     end_month: EndMonthParam = None,
     include_drafts: IncludeDraftsParam = False,
@@ -246,7 +246,7 @@ async def get_income_over_time(
     },
 )
 async def get_income_breakdown(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     month: MonthParam = None,
     days: DaysParam = None,
     include_drafts: IncludeDraftsParam = False,
@@ -279,7 +279,7 @@ async def get_income_breakdown(
     },
 )
 async def get_net_income_over_time(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     months: MonthsParam = 12,
     end_month: EndMonthParam = None,
     include_drafts: IncludeDraftsParam = False,
@@ -312,7 +312,7 @@ async def get_net_income_over_time(
     },
 )
 async def get_savings_rate_over_time(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     months: MonthsParam = 12,
     end_month: EndMonthParam = None,
     include_drafts: IncludeDraftsParam = False,
@@ -347,7 +347,7 @@ async def get_savings_rate_over_time(
     },
 )
 async def get_net_worth_over_time(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     months: MonthsParam = 12,
     end_month: EndMonthParam = None,
     include_drafts: IncludeDraftsParam = True,
@@ -379,7 +379,7 @@ async def get_net_worth_over_time(
     },
 )
 async def get_balances_over_time(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     months: MonthsParam = 12,
     end_month: EndMonthParam = None,
     include_drafts: IncludeDraftsParam = True,
@@ -412,7 +412,7 @@ async def get_balances_over_time(
     },
 )
 async def get_month_comparison(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     month: MonthParam = None,
     include_drafts: IncludeDraftsParam = False,
 ) -> MonthComparisonResponse:
@@ -443,7 +443,7 @@ async def get_month_comparison(
     },
 )
 async def get_sankey_data(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     month: MonthParam = None,
     days: DaysParam = None,
     include_drafts: IncludeDraftsParam = False,

--- a/services/backend/src/swen/presentation/api/analytics/routers/dashboard.py
+++ b/services/backend/src/swen/presentation/api/analytics/routers/dashboard.py
@@ -11,7 +11,7 @@ from swen.presentation.api.analytics.schemas.dashboard import (
     DashboardSummaryResponse,
     SpendingBreakdownResponse,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ MonthFilter = Annotated[
     },
 )
 async def get_dashboard_summary(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     days: DaysFilter = None,
     month: MonthFilter = None,
 ) -> DashboardSummaryResponse:
@@ -74,7 +74,7 @@ async def get_dashboard_summary(
     },
 )
 async def get_spending_breakdown(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     days: DaysFilter = None,
     month: MonthFilter = None,
 ) -> SpendingBreakdownResponse:
@@ -109,7 +109,7 @@ async def get_spending_breakdown(
     },
 )
 async def get_balances(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> BalancesResponse:
     """
     Get current balances for all asset accounts.

--- a/services/backend/src/swen/presentation/api/analytics/routers/exports.py
+++ b/services/backend/src/swen/presentation/api/analytics/routers/exports.py
@@ -18,7 +18,7 @@ from swen.presentation.api.analytics.schemas.exports import (
     FullExportResponse,
     TransactionExportListResponse,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ IncludeDraftsParam = Annotated[
     },
 )
 async def export_transactions(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     days: DaysFilter = 0,
     status: StatusFilter = None,
     iban: IbanFilter = None,
@@ -106,7 +106,7 @@ async def export_transactions(
     },
 )
 async def export_accounts(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     account_type: AccountTypeFilter = None,
     include_inactive: IncludeInactiveFilter = False,
 ) -> AccountExportListResponse:
@@ -136,7 +136,7 @@ async def export_accounts(
     },
 )
 async def export_full(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     days: DaysFilter = 0,
 ) -> FullExportResponse:
     """
@@ -179,7 +179,7 @@ async def export_full(
     },
 )
 async def export_excel_report(  # noqa: PLR0913
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     start_date: StartDateParam = None,
     end_date: EndDateParam = None,
     days: DaysFilter = 0,

--- a/services/backend/src/swen/presentation/api/auth/routers/auth.py
+++ b/services/backend/src/swen/presentation/api/auth/routers/auth.py
@@ -16,8 +16,8 @@ from swen.presentation.api.auth.schemas.auth import (
     UserResponse,
 )
 from swen.presentation.api.dependencies import (
-    AuthenticatedUser,
-    IdentityRepoFactory,
+    AuthenticatedUserDep,
+    IdentityRepoFactoryDep,
     JWTServiceDep,
     PasswordHashingServiceDep,
     SettingsDep,
@@ -109,7 +109,7 @@ def _create_auth_response(
 async def register(  # NOQA: PLR0913
     request: RegisterRequest,
     response: Response,
-    factory: IdentityRepoFactory,
+    factory: IdentityRepoFactoryDep,
     jwt_service: JWTServiceDep,
     password_service: PasswordHashingServiceDep,
     settings: SettingsDep,
@@ -166,7 +166,7 @@ async def register(  # NOQA: PLR0913
 async def login(  # NOQA: PLR0913
     request: LoginRequest,
     response: Response,
-    factory: IdentityRepoFactory,
+    factory: IdentityRepoFactoryDep,
     jwt_service: JWTServiceDep,
     password_service: PasswordHashingServiceDep,
     settings: SettingsDep,
@@ -220,7 +220,7 @@ async def login(  # NOQA: PLR0913
 )
 async def refresh_token(  # NOQA: PLR0913
     response: Response,
-    factory: IdentityRepoFactory,
+    factory: IdentityRepoFactoryDep,
     jwt_service: JWTServiceDep,
     password_service: PasswordHashingServiceDep,
     settings: SettingsDep,
@@ -272,7 +272,7 @@ async def refresh_token(  # NOQA: PLR0913
         401: {"description": "Not authenticated"},
     },
 )
-async def get_me(user: AuthenticatedUser) -> UserResponse:
+async def get_me(user: AuthenticatedUserDep) -> UserResponse:
     """
     Get the current authenticated user's information.
 
@@ -298,8 +298,8 @@ async def get_me(user: AuthenticatedUser) -> UserResponse:
 )
 async def change_password(
     request: ChangePasswordRequest,
-    user: AuthenticatedUser,
-    factory: IdentityRepoFactory,
+    user: AuthenticatedUserDep,
+    factory: IdentityRepoFactoryDep,
     jwt_service: JWTServiceDep,
     password_service: PasswordHashingServiceDep,
 ) -> None:
@@ -365,7 +365,7 @@ async def logout(
 )
 async def forgot_password(
     request: ForgotPasswordRequest,
-    factory: IdentityRepoFactory,
+    factory: IdentityRepoFactoryDep,
     settings: SettingsDep,
     password_service: PasswordHashingServiceDep,
 ) -> dict:
@@ -387,7 +387,7 @@ async def forgot_password(
 )
 async def reset_password(
     request: ResetPasswordRequest,
-    factory: IdentityRepoFactory,
+    factory: IdentityRepoFactoryDep,
     settings: SettingsDep,
     password_service: PasswordHashingServiceDep,
 ) -> None:

--- a/services/backend/src/swen/presentation/api/banking/routers/bank_account_setup.py
+++ b/services/backend/src/swen/presentation/api/banking/routers/bank_account_setup.py
@@ -10,7 +10,7 @@ from swen.presentation.api.banking.schemas.bank_connections import (
     SetupBankRequest,
     SetupBankResponse,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ router = APIRouter()
 )
 async def setup_bank_accounts(
     blz: str,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     request: SetupBankRequest,
 ) -> SetupBankResponse:
     """Import discovered bank accounts with user injected custom names."""

--- a/services/backend/src/swen/presentation/api/banking/routers/credentials.py
+++ b/services/backend/src/swen/presentation/api/banking/routers/credentials.py
@@ -24,7 +24,7 @@ from swen.presentation.api.banking.schemas.credentials import (
     CredentialToUpdate,
     StoredCredentialList,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ router = APIRouter()
         200: {"description": "List of stored credentials"},
     },
 )
-async def list_credentials(factory: RepoFactory) -> StoredCredentialList:
+async def list_credentials(factory: RepoFactoryDep) -> StoredCredentialList:
     """
     List all stored bank credentials for the current user.
 
@@ -63,7 +63,7 @@ async def list_credentials(factory: RepoFactory) -> StoredCredentialList:
 )
 async def store_credentials(
     request: CredentialToStore,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> None:
     """
     Store bank credentials securely for automated sync.
@@ -104,7 +104,7 @@ async def store_credentials(
 async def update_credentials_tan(
     blz: str,
     request: CredentialToUpdate,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> None:
     """
     Update the TAN method and medium for already-stored bank credentials.
@@ -149,7 +149,7 @@ async def update_credentials_tan(
 )
 async def delete_credentials(
     blz: str,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> None:
     """
     Delete stored credentials for a bank.

--- a/services/backend/src/swen/presentation/api/banking/routers/discovery.py
+++ b/services/backend/src/swen/presentation/api/banking/routers/discovery.py
@@ -15,7 +15,7 @@ from swen.presentation.api.banking.schemas.discovery import (
     BankInfoResponse,
     TanMethodQueryRequest,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ router = APIRouter()
 )
 async def lookup_bank(
     blz: str,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> BankInfoResponse:
     """Lookup bank information by BLZ."""
     # Validate BLZ format
@@ -68,7 +68,7 @@ async def lookup_bank(
 )
 async def discover_bank_accounts(
     blz: str,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> BankDiscoveryResultResponse:
     """
     Connect to bank and discover accounts without importing them.
@@ -127,7 +127,7 @@ async def discover_bank_accounts(
 )
 async def query_tan_methods(
     request: TanMethodQueryRequest,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> TANMethodsResponse:
     """
     Query available TAN methods from the bank.

--- a/services/backend/src/swen/presentation/api/dependencies.py
+++ b/services/backend/src/swen/presentation/api/dependencies.py
@@ -21,11 +21,17 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-from swen.application.ports.ml_service import MLServicePort
+from swen.application.ports import AccountClassifierTrainingPort
+from swen.domain.integration.ports.counter_account_proposal_port import (
+    CounterAccountProposalPort,
+)
 from swen.infrastructure.adapters.identity import IdentityAdapter
-from swen.infrastructure.integration.ml import (
-    MLServiceAdapter,
+from swen.infrastructure.integration import (
+    MLAccountClassifierTrainingAdapter,
     MLServiceClient,
+)
+from swen.infrastructure.integration.adapters.counter_account_resolution.ml import (
+    MLCounterAccountAdapter,
 )
 from swen.infrastructure.persistence.sqlalchemy.repositories import (
     SQLAlchemyRepositoryFactory,
@@ -301,16 +307,22 @@ def get_ml_client() -> MLServiceClient:
 
 
 @lru_cache(maxsize=1)
-def get_ml_port() -> MLServicePort | None:
-    """Get the ML service port for application layer (singleton)."""
+def get_classifier_training_port() -> AccountClassifierTrainingPort | None:
+    """Get the account classifier training port (singleton)."""
     settings = get_settings()
     if not settings.ml_service_enabled:
         return None
-    return MLServiceAdapter(client=get_ml_client())
+    return MLAccountClassifierTrainingAdapter(client=get_ml_client())
+
+
+@lru_cache(maxsize=1)
+def get_counter_account_proposal_port() -> CounterAccountProposalPort:
+    """Get the counter-account proposal port (singleton)."""
+    return MLCounterAccountAdapter(ml_client=get_ml_client())
 
 
 # DB session
-DBSession = Annotated[AsyncSession, Depends(get_db_session)]
+DBSessionDep = Annotated[AsyncSession, Depends(get_db_session)]
 # Settings Dependency
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 # Encryption and PW dependeicyues
@@ -321,15 +333,22 @@ PasswordHashingServiceDep = Annotated[
 ]
 
 # User + Admin auth dependencies
-AuthenticatedUser = Annotated[User, Depends(get_current_user)]
-AdminUser = Annotated[User, Depends(require_admin)]
+AuthenticatedUserDep = Annotated[User, Depends(get_current_user)]
+AdminUserDep = Annotated[User, Depends(require_admin)]
 
 # Repository factories
-RepoFactory = Annotated[SQLAlchemyRepositoryFactory, Depends(get_repository_factory)]
-IdentityRepoFactory = Annotated[
-    IdentityRepositoryFactorySQLAlchemy, Depends(get_identity_repository_factory)
+RepoFactoryDep = Annotated[SQLAlchemyRepositoryFactory, Depends(get_repository_factory)]
+IdentityRepoFactoryDep = Annotated[
+    IdentityRepositoryFactorySQLAlchemy,
+    Depends(get_identity_repository_factory),
 ]
 
-# ML service dependencies TODO: Tihnk about unification of these two.
-MLClient = Annotated[MLServiceClient, Depends(get_ml_client)]
-MLPort = Annotated[MLServicePort | None, Depends(get_ml_port)]
+# ML service dependencies
+ClassifierTrainingPortDep = Annotated[
+    AccountClassifierTrainingPort | None,
+    Depends(get_classifier_training_port),
+]
+CounterAccountPortDep = Annotated[
+    CounterAccountProposalPort,
+    Depends(get_counter_account_proposal_port),
+]

--- a/services/backend/src/swen/presentation/api/integration/routers/bank_accounts.py
+++ b/services/backend/src/swen/presentation/api/integration/routers/bank_accounts.py
@@ -11,7 +11,7 @@ from swen.presentation.api.accounting.schemas.accounts import (
     BankAccountRenameRequest,
     BankAccountResponse,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ router = APIRouter()
         200: {"description": "List of bank accounts with mappings"},
     },
 )
-async def list_bank_accounts(factory: RepoFactory) -> BankAccountListResponse:
+async def list_bank_accounts(factory: RepoFactoryDep) -> BankAccountListResponse:
     """
     List all imported bank accounts with their mapping information.
 
@@ -50,7 +50,7 @@ async def list_bank_accounts(factory: RepoFactory) -> BankAccountListResponse:
 async def rename_bank_account(
     iban: str,
     request: BankAccountRenameRequest,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> BankAccountResponse:
     """
     Rename an imported bank account.

--- a/services/backend/src/swen/presentation/api/integration/routers/imports.py
+++ b/services/backend/src/swen/presentation/api/integration/routers/imports.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Query
 
 from swen.application.integration.queries import ListImportsQuery
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 from swen.presentation.api.integration.schemas.imported_transactions import (
     ImportedTransactionsListResponse,
 )
@@ -30,7 +30,7 @@ IbanFilter = Annotated[str | None, Query(description="Filter by bank account IBA
     },
 )
 async def list_imports(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
     days: DaysFilter = 30,
     limit: LimitFilter = 50,
     failed_only: FailedOnlyFilter = False,

--- a/services/backend/src/swen/presentation/api/integration/routers/mappings.py
+++ b/services/backend/src/swen/presentation/api/integration/routers/mappings.py
@@ -10,7 +10,7 @@ from swen.application.integration.queries import (
     ListAccountMappingsQuery,
 )
 from swen.domain.accounting.entities import AccountType
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 from swen.presentation.api.integration.schemas.mappings import (
     AccountMappingListResponse,
     AccountMappingResponse,
@@ -31,7 +31,7 @@ router = APIRouter()
         200: {"description": "List of bank account mappings"},
     },
 )
-async def list_mappings(factory: RepoFactory) -> AccountMappingListResponse:
+async def list_mappings(factory: RepoFactoryDep) -> AccountMappingListResponse:
     """
     List all bank account to ledger account mappings.
 
@@ -58,7 +58,7 @@ async def list_mappings(factory: RepoFactory) -> AccountMappingListResponse:
 )
 async def get_mapping_by_iban(
     iban: str,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> AccountMappingResponse:
     """
     Get a specific bank account mapping by IBAN.
@@ -89,7 +89,7 @@ async def get_mapping_by_iban(
 )
 async def create_external_account_mapping(
     request: ExternalAccountCreateRequest,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> ExternalAccountCreateResponse:
     """
     Create an account mapping for an external bank account.

--- a/services/backend/src/swen/presentation/api/integration/routers/reconciliation.py
+++ b/services/backend/src/swen/presentation/api/integration/routers/reconciliation.py
@@ -8,7 +8,7 @@ from swen.application.integration.queries import (
     BankConnectionDetailsQuery,
     ReconciliationQuery,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 from swen.presentation.api.integration.schemas.reconciliation import (
     BankConnectionDetailsResponse,
     ReconciliationResponse,
@@ -26,7 +26,7 @@ router = APIRouter()
         200: {"description": "Reconciliation results"},
     },
 )
-async def get_reconciliation(factory: RepoFactory) -> ReconciliationResponse:
+async def get_reconciliation(factory: RepoFactoryDep) -> ReconciliationResponse:
     """
     Compare bank-reported balances with bookkeeping calculated balances.
 
@@ -54,7 +54,7 @@ async def get_reconciliation(factory: RepoFactory) -> ReconciliationResponse:
 )
 async def get_bank_connection_details(
     blz: str,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> BankConnectionDetailsResponse:
     """
     Get details for a bank connection including all accounts and reconciliation.

--- a/services/backend/src/swen/presentation/api/integration/routers/sync.py
+++ b/services/backend/src/swen/presentation/api/integration/routers/sync.py
@@ -17,13 +17,10 @@ from swen.application.integration.queries import (
     SyncStatusQuery,
 )
 from swen.domain.shared.exceptions import DomainException, ErrorCode
-from swen.infrastructure.integration.adapters.counter_account_resolution.ml import (
-    MLCounterAccountAdapter,
-)
 from swen.infrastructure.integration.adapters.event_publisher import (
     SseSyncEventPublisher,
 )
-from swen.presentation.api.dependencies import MLClient, RepoFactory
+from swen.presentation.api.dependencies import CounterAccountPortDep, RepoFactoryDep
 from swen.presentation.api.integration.schemas.sync import (
     SyncRunRequest,
     SyncStatusResponse,
@@ -46,8 +43,8 @@ router = APIRouter()
     },
 )
 async def run_sync_streaming(
-    factory: RepoFactory,
-    ml_client: MLClient,
+    factory: RepoFactoryDep,
+    resolution_port: CounterAccountPortDep,
     request: Optional[SyncRunRequest] = None,
 ) -> StreamingResponse:
     """
@@ -113,7 +110,7 @@ async def run_sync_streaming(
         try:
             command = await SyncBankAccountsCommand.from_factory(
                 factory,
-                resolution_port=MLCounterAccountAdapter(ml_client),
+                resolution_port=resolution_port,
                 publisher=publisher,
             )
         except DomainException as e:
@@ -186,7 +183,7 @@ def _format_sse_event(event_type: str, data: dict) -> str:
     },
 )
 async def get_sync_status(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> SyncStatusResponse:
     """
     Get transaction sync status and statistics.

--- a/services/backend/src/swen/presentation/api/onboarding/routers/onboarding.py
+++ b/services/backend/src/swen/presentation/api/onboarding/routers/onboarding.py
@@ -9,7 +9,7 @@ from swen.application.system.queries.onboarding import OnboardingStatusQuery
 from swen.application.system.queries.onboarding.onboarding_status_query import (
     OnboardingStatusDTO,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class OnboardingStatusResponse(OnboardingStatusDTO):
         200: {"description": "Onboarding status for the current user"},
     },
 )
-async def get_onboarding_status(factory: RepoFactory) -> OnboardingStatusResponse:
+async def get_onboarding_status(factory: RepoFactoryDep) -> OnboardingStatusResponse:
     """
     Get the onboarding status for the current user.
 

--- a/services/backend/src/swen/presentation/api/settings/routers/preferences.py
+++ b/services/backend/src/swen/presentation/api/settings/routers/preferences.py
@@ -19,7 +19,7 @@ from swen.application.settings.queries import (
     GetAvailableWidgetsQuery,
     GetUserSettingsQuery,
 )
-from swen.presentation.api.dependencies import RepoFactory
+from swen.presentation.api.dependencies import RepoFactoryDep
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ class AvailableWidgetsResponse(AvailableWidgetsDTO):
     },
 )
 async def get_preferences(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> UserSettingsResponse:
     """
     Get the current user's preferences.
@@ -115,7 +115,7 @@ async def get_preferences(
 )
 async def update_preferences(
     request: UserSettingsUpdateRequest,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> UserSettingsResponse:
     """
     Update user preferences.
@@ -144,7 +144,7 @@ async def update_preferences(
     },
 )
 async def reset_preferences(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> UserSettingsResponse:
     """Reset all user preferences to default values."""
     command = ResetUserSettingsCommand.from_factory(factory)
@@ -162,7 +162,7 @@ async def reset_preferences(
     },
 )
 async def get_dashboard_settings(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> DashboardSettingsResponse:
     """Get the current user's dashboard widget configuration."""
     query = GetUserSettingsQuery.from_factory(factory)
@@ -180,7 +180,7 @@ async def get_dashboard_settings(
 )
 async def update_dashboard_settings(
     request: UserSettingsUpdateRequest,
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> DashboardSettingsResponse:
     """Update dashboard widget configuration."""
     if request.enabled_widgets is None and request.widget_settings is None:
@@ -216,7 +216,7 @@ async def update_dashboard_settings(
     },
 )
 async def reset_dashboard_settings(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> DashboardSettingsResponse:
     """Reset dashboard to default widget configuration."""
     # Reset all settings, then return just dashboard
@@ -235,7 +235,7 @@ async def reset_dashboard_settings(
     },
 )
 async def list_available_widgets(
-    factory: RepoFactory,
+    factory: RepoFactoryDep,
 ) -> AvailableWidgetsResponse:
     """Get all available dashboard widgets with their metadata."""
     query = GetAvailableWidgetsQuery.from_factory(factory)

--- a/services/backend/tests/swen/unit/infrastructure/persistence/test_account_repository.py
+++ b/services/backend/tests/swen/unit/infrastructure/persistence/test_account_repository.py
@@ -279,6 +279,7 @@ class _FakeAsyncpgWrapperError(Exception):
         super().__init__("boom")
         self.sqlstate = sqlstate
         self.pgcode = sqlstate
+        self.constraint_name: str | None = None
         if cause is not None:
             self.__cause__ = cause
 

--- a/services/contracts/swen_ml_contracts/common.py
+++ b/services/contracts/swen_ml_contracts/common.py
@@ -2,11 +2,13 @@
 
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AccountOption(BaseModel):
     """Account available for classification."""
+
+    model_config = ConfigDict(from_attributes=True)
 
     account_id: UUID
     account_number: str = Field(..., max_length=10)


### PR DESCRIPTION
## Description

Change the generic MLPort name to AccountClassificationTrainingPort to make the scope more narrow to what it actually does. Before, it was easily confused with the CounterAccountProposalPort whihc also did ML stuff in its implementations.

Moreover, we migrated some dataclasses to pyudantic.

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [ ] `[Feat]` - New feature
- [ ] `[Fix]` - Bug fix
- [x] `[Refactor]` - Code refactoring (no functional change)
- [ ] `[Docs]` - Documentation update
- [ ] `[Test]` - Test additions or updates
- [ ] `[Chore]` - Maintenance (dependencies, CI, configs)

## Checklist

- [x] PR title follows the format: `[Type] Short description`
- [x] Code follows project conventions
- [x] Tests added/updated where applicable
- [x] Documentation updated if needed

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
