### PR TITLE
[Chore]: exclude major npm bumps from dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,9 +40,14 @@ updates:
       - dependency-name: "@eslint/js"
         update-types: ["version-update:semver-major"]
     groups:
+      # Only bundle minor/patch bumps together; majors get their own PR
+      # each so a breaking change doesn't get buried in a 40-package batch.
       npm-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Description

The npm-dependencies group bundled every update together regardless of semver, so weekly PRs mixed safe patch bumps with breaking majors (e.g. PR #96 bundled tailwindcss 3->4 and typescript 5->7 into one PR, breaking CI). Restrict the group to minor/patch so majors surface as individual, reviewable PRs.

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [ ] `[Feat]` - New feature
- [ ] `[Fix]` - Bug fix
- [ ] `[Refactor]` - Code refactoring (no functional change)
- [ ] `[Docs]` - Documentation update
- [ ] `[Test]` - Test additions or updates
- [x] `[Chore]` - Maintenance (dependencies, CI, configs)

## Checklist

- [x] PR title follows the format: `[Type] Short description`
- [x] Code follows project conventions
- [x] Tests added/updated where applicable
- [x] Documentation updated if needed

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
