### PR TITLE
[Chore] Bump python to 3.13 consistently

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     env_file:
       - ./config/.env
     # Uncomment to connect a DB viewer from host
-    ports:
-      - "5432:5432"
+    # ports:
+    #   - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./services/database/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ SWEN is a privacy-first personal finance application you run on your own hardwar
 
 -   :robot: **ML Classification**
 
-    A multi-tier ML pipeline (preprocessing → user-history k-NN → enrichment + keywords → account embedding similarity → fallback) automatically assigns counter-accounts. Learns from your corrections.
+    A four-stage ML pipeline (preprocessing → example matching → enrichment + keywords → anchor embedding similarity) automatically assigns counter-accounts, falling back to manual review when nothing matches. Learns from your corrections.
 
 -   :house: **Fully Self-Hosted**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "swen-workspace"
 version = "0.0.0"
 description = "SWEN - Personal finance management system"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 # Virtual root package with no direct dependencies, everything comes from workspace members
 dependencies = []
 
@@ -51,5 +51,5 @@ exclude = ["_deprecated"]
 select = ["E", "F", "I", "UP", "B", "SIM"]
 
 [tool.pyright]
-pythonVersion = "3.11"
+pythonVersion = "3.13"
 typeCheckingMode = "basic"

--- a/services/backend/pyproject.toml
+++ b/services/backend/pyproject.toml
@@ -3,7 +3,7 @@ name = "swen-backend"
 version = "0.1.0"
 description = "SWEN - Personal finance management backend"
 authors = [{ name = "Malte Winckler", email = "malte@nichts-ist-einfach.de" }]
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.13,<3.14"
 dependencies = [
     "python-dotenv>=1.2.1",
     "pydantic>=2.11.7",

--- a/services/contracts/pyproject.toml
+++ b/services/contracts/pyproject.toml
@@ -2,7 +2,7 @@
 name = "swen-ml-contracts"
 version = "0.1.0"
 description = "Shared API contracts between SWEN services"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "pydantic>=2.5.0",
 ]
@@ -15,5 +15,5 @@ build-backend = "hatchling.build"
 packages = ["swen_ml_contracts"]
 
 [tool.pyright]
-pythonVersion = "3.11"
+pythonVersion = "3.13"
 typeCheckingMode = "strict"

--- a/services/ml/pyproject.toml
+++ b/services/ml/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 packages = ["swen_ml"]
 
 [tool.pyright]
-pythonVersion = "3.11"
+pythonVersion = "3.13"
 typeCheckingMode = "basic"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Description

Via dependencies, we had python 3.13 everywhere anyway. Now we make it explicit throughout all workspaces.

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [ ] `[Feat]` - New feature
- [ ] `[Fix]` - Bug fix
- [ ] `[Refactor]` - Code refactoring (no functional change)
- [ ] `[Docs]` - Documentation update
- [ ] `[Test]` - Test additions or updates
- [x] `[Chore]` - Maintenance (dependencies, CI, configs)

## Checklist

- [x] PR title follows the format: `[Type] Short description`
- [x] Code follows project conventions
- [x] Tests added/updated where applicable
- [x] Documentation updated if needed

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
