### PR TITLE
[Feat] Add Subaccount Option to Account Creation Modal

### DIFF
--- a/services/frontend/src/components/accounts/CreateAccountModal.test.tsx
+++ b/services/frontend/src/components/accounts/CreateAccountModal.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { render, setupUser } from '../../../tests/test-utils'
+import { CreateAccountModal } from './CreateAccountModal'
+
+vi.mock('@/api', () => ({
+  createAccount: vi.fn(),
+  createExternalAccount: vi.fn(),
+  listAccounts: vi.fn(),
+}))
+
+import { createAccount, listAccounts } from '@/api'
+
+const mockCreateAccount = createAccount as ReturnType<typeof vi.fn>
+const mockListAccounts = listAccounts as ReturnType<typeof vi.fn>
+
+const existingExpenseAccounts = [
+  {
+    id: 'parent-1',
+    name: 'Food & Drink',
+    account_number: '4000',
+    account_type: 'EXPENSE',
+    is_active: true,
+    parent_id: null,
+    currency: 'EUR',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+]
+
+describe('CreateAccountModal', () => {
+  const mockOnClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListAccounts.mockResolvedValue({ items: existingExpenseAccounts, total: 1 })
+  })
+
+  it('shows a Parent Account selector listing same-type accounts', async () => {
+    render(<CreateAccountModal isOpen onClose={mockOnClose} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Parent Account')).toBeInTheDocument()
+    })
+
+    const parentSelect = screen.getByRole('combobox')
+    await waitFor(() => {
+      expect(parentSelect).toHaveTextContent('Food & Drink')
+    })
+  })
+
+  it('sends parent_id through to createAccount when a parent is selected', async () => {
+    const user = setupUser()
+    mockCreateAccount.mockResolvedValueOnce({ id: 'new-account' })
+
+    render(<CreateAccountModal isOpen onClose={mockOnClose} />)
+
+    await user.type(screen.getByPlaceholderText('e.g., Groceries'), 'Groceries')
+
+    const parentSelect = await screen.findByRole('combobox')
+    await waitFor(() => expect(parentSelect).toHaveTextContent('Food & Drink'))
+    await user.selectOptions(parentSelect, 'parent-1')
+
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(mockCreateAccount).toHaveBeenCalledWith(
+        expect.objectContaining({ parent_id: 'parent-1' })
+      )
+    })
+  })
+
+  it('hides the Parent Account field once an IBAN is entered for an asset account', async () => {
+    const user = setupUser()
+
+    render(<CreateAccountModal isOpen onClose={mockOnClose} />)
+
+    await user.click(screen.getByRole('button', { name: /bank \/ savings/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Parent Account')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByPlaceholderText(/DE89/), 'DE89370400440532013000')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Parent Account')).not.toBeInTheDocument()
+    })
+  })
+
+  it('clears a selected parent when the account type changes', async () => {
+    const user = setupUser()
+
+    render(<CreateAccountModal isOpen onClose={mockOnClose} />)
+
+    const parentSelect = await screen.findByRole('combobox')
+    await waitFor(() => expect(parentSelect).toHaveTextContent('Food & Drink'))
+    await user.selectOptions(parentSelect, 'parent-1')
+    expect(parentSelect).toHaveValue('parent-1')
+
+    await user.click(screen.getByRole('button', { name: /income source/i }))
+    await user.click(screen.getByRole('button', { name: /expense category/i }))
+
+    const resetSelect = await screen.findByRole('combobox')
+    expect(resetSelect).toHaveValue('')
+  })
+})

--- a/services/frontend/src/components/accounts/CreateAccountModal.tsx
+++ b/services/frontend/src/components/accounts/CreateAccountModal.tsx
@@ -25,6 +25,7 @@ import { createAccount, createExternalAccount } from '@/api'
 import type { AccountType } from '@/types/api'
 import { cn } from '@/lib/utils'
 import { IBANInput, accountTypeLabels, normalizeAccountType } from '@/components/accounts'
+import { ParentAccountSelect } from './ParentAccountSelect'
 
 type CreateStep = 'form' | 'success'
 
@@ -35,6 +36,7 @@ type CreateFormState = {
   account_number: string
   currency: string
   description: string
+  parent_id: string | null
 }
 
 type CreateResult = {
@@ -56,6 +58,7 @@ const INITIAL_FORM: CreateFormState = {
   account_number: '',
   currency: 'EUR',
   description: '',
+  parent_id: null,
 }
 
 function supportsIban(type: AccountType) {
@@ -98,6 +101,7 @@ export function CreateAccountModal({ isOpen, onClose }: CreateAccountModalProps)
         account_type: data.account_type,
         currency,
         description: data.description?.trim() || undefined,
+        parent_id: data.parent_id ?? undefined,
       })
       return {
         accountName: data.name.trim(),
@@ -145,6 +149,8 @@ export function CreateAccountModal({ isOpen, onClose }: CreateAccountModalProps)
 
     createAccountMutation.mutate(form)
   }
+
+  const willCreateExternal = supportsIban(form.account_type) && form.iban.trim().length > 0
 
   return (
     <Modal
@@ -215,7 +221,7 @@ export function CreateAccountModal({ isOpen, onClose }: CreateAccountModalProps)
                   <button
                     key={type}
                     type="button"
-                    onClick={() => setForm({ ...form, account_type: type, iban: '' })}
+                    onClick={() => setForm({ ...form, account_type: type, iban: '', parent_id: null })}
                     className={cn(
                       'p-3 rounded-lg border-2 text-left transition-all',
                       form.account_type === type
@@ -273,6 +279,20 @@ export function CreateAccountModal({ isOpen, onClose }: CreateAccountModalProps)
                   onChange={(e) => setForm({ ...form, description: e.target.value })}
                   placeholder="Keywords for AI classification..."
                   maxLength={500}
+                />
+              </FormField>
+            )}
+
+            {!willCreateExternal && (
+              <FormField
+                label="Parent Account"
+                helperText="Organize accounts in a hierarchy (max 3 levels). Optional."
+              >
+                <ParentAccountSelect
+                  accountType={form.account_type}
+                  value={form.parent_id}
+                  onChange={(parentId) => setForm({ ...form, parent_id: parentId })}
+                  disabled={createAccountMutation.isPending}
                 />
               </FormField>
             )}

--- a/services/frontend/src/components/accounts/ParentAccountSelect.tsx
+++ b/services/frontend/src/components/accounts/ParentAccountSelect.tsx
@@ -11,8 +11,8 @@ import { Select } from '@/components/ui'
 import type { AccountType } from '@/types/api'
 
 interface ParentAccountSelectProps {
-  /** Current account ID (to exclude from options) */
-  accountId: string
+  /** Current account ID (to exclude from options). Omit when creating a new account. */
+  accountId?: string
   /** Account type to filter by (only same-type accounts can be parents) */
   accountType: AccountType
   /** Currently selected parent ID (null = no parent) */
@@ -49,7 +49,7 @@ export function ParentAccountSelect({
 
   // Build options for Select component
   const options = [
-    { value: '', label: '(None - Top Level)' },
+    { value: '', label: 'None', muted: true },
     ...eligibleParents.map((account) => ({
       value: account.id,
       label: `${account.account_number} - ${account.name}`,
@@ -69,6 +69,7 @@ export function ParentAccountSelect({
       disabled={disabled || isLoading}
       placeholder={isLoading ? 'Loading...' : undefined}
       error={hasError}
+      className={!value ? 'text-text-muted' : undefined}
     />
   )
 }

--- a/services/frontend/src/components/ui/select.tsx
+++ b/services/frontend/src/components/ui/select.tsx
@@ -6,6 +6,8 @@ export interface SelectOption {
   value: string
   label: string
   disabled?: boolean
+  /** Render this option's label in muted text, e.g. for a "None" default. */
+  muted?: boolean
 }
 
 export interface SelectProps extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'onChange'> {
@@ -29,12 +31,12 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           onChange={handleChange}
           disabled={disabled}
           className={cn(
-            'flex h-10 w-full appearance-none rounded-lg border px-3 pr-10 py-2 text-sm',
-            'bg-bg-base border-border-subtle text-text-primary',
-            'focus:outline-none focus:ring-2 focus:ring-accent-primary/50 focus:border-accent-primary',
-            'disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-bg-hover',
-            'transition-colors cursor-pointer',
-            error && 'border-accent-danger focus:ring-accent-danger/50 focus:border-accent-danger',
+            'flex h-10 w-full appearance-none rounded-lg border bg-bg-elevated px-3 pr-10 py-2 text-sm',
+            'border-border-default text-text-primary',
+            'transition-colors duration-fast cursor-pointer',
+            'focus:outline-none focus:ring-1 focus:border-accent-primary focus:ring-accent-primary',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            error && 'border-accent-danger focus:border-accent-danger focus:ring-accent-danger',
             className
           )}
           {...props}
@@ -45,7 +47,12 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
             </option>
           )}
           {options.map((option) => (
-            <option key={option.value} value={option.value} disabled={option.disabled}>
+            <option
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled}
+              style={option.muted ? { color: 'var(--text-muted)' } : undefined}
+            >
               {option.label}
             </option>
           ))}


### PR DESCRIPTION
## Description

Now, we allow sub account creation directly in the account creation modal. Sub accounts are so far only supported for non-iban accounts.

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [x] `[Feat]` - New feature
- [ ] `[Fix]` - Bug fix
- [ ] `[Refactor]` - Code refactoring (no functional change)
- [ ] `[Docs]` - Documentation update
- [ ] `[Test]` - Test additions or updates
- [ ] `[Chore]` - Maintenance (dependencies, CI, configs)

## Checklist

- [x] PR title follows the format: `[Type] Short description`
- [x] Code follows project conventions
- [x] Tests added/updated where applicable
- [x] Documentation updated if needed

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
