### PR TITLE
[Fix] Postgres 18 refuses to start — mount the volume at /var/lib/postgresql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     # ports:
     #   - "5432:5432"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
       - ./services/database/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]


### PR DESCRIPTION
## Description

`docker compose up -d` fails on a clean checkout: the `postgres` container exits
immediately, and every service that waits on `postgres: condition: service_healthy`
never starts.

The postgres 18 images store data under a major-version subdirectory
(`/var/lib/postgresql/18/docker`) and abort when they find a mount at the old
`/var/lib/postgresql/data` path — **even when that volume is completely empty**:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).
       ...
       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)

       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql which will then place PostgreSQL data in a
       subdirectory ...
```

This moves the mount to `/var/lib/postgresql`, which is exactly what the image's
own error message recommends (see docker-library/postgres#1259).

**No migration concern:** this repo has only ever used `postgres:18-alpine` —
`git log -S "postgres:17"` and `-S "postgres:16"` on `docker-compose.yml` are both
empty — so no existing deployment can be holding data at the old path.

### Reproduce

```sh
docker volume rm -f pgtest; docker volume create pgtest
docker run --rm -e POSTGRES_PASSWORD=x \
  -v pgtest:/var/lib/postgresql/data postgres:18-alpine
# -> the error above, container exits 1
```

Verified on Docker 29.7.2, with both a named volume and a bind mount. With the
mount moved to `/var/lib/postgresql` the stack comes up and stays healthy; I have
been running both projects this way.

## Type of Change

- [x] `[Fix]` - Bug fix

## Checklist

- [x] PR title follows the format: `[Type] Short description`
- [x] Code follows project conventions
- [ ] Tests added/updated where applicable — compose-only change, no code path to test
- [ ] Documentation updated if needed — `docs/deployment/docker.md` needs no change

## Related Issues

None open that I could find.
